### PR TITLE
feat(benchmark): grand leaderboard + fix pipeline LLM source

### DIFF
--- a/benchmarks/published/grand_leaderboard.md
+++ b/benchmarks/published/grand_leaderboard.md
@@ -1,0 +1,106 @@
+# TalkBot Grand Leaderboard
+
+- Generated: 2026-03-01T21:50:32Z
+- Published runs scanned: 25
+- Unique model × provider combos: 24
+- Total model-run records: 217
+
+Best result per model across **all** published benchmark runs.
+Success% = fraction of scenarios where the model answered correctly.
+
+## All Models — Best Ever
+
+| # | Model | Provider | Success% | Avg ms | P95 ms | Tool Sel% | Scenarios | Best Run |
+|---:|---|---|---:|---:|---:|---:|---:|---|
+| 1 | google/gemini-2.5-flash-lite | openrouter | 100.0% | 910 | 1234 | 100.0% | 10 | next_run-20260228-234132 (2026-02-28) |
+| 2 | google/gemini-2.5-pro | openrouter | 100.0% | 4900 | 8484 | 100.0% | 10 | next_run-20260228-234132 (2026-02-28) |
+| 3 | openai/gpt-4o-mini | openrouter | 90.0% | 1880 | 3107 | 95.5% | 10 | validated-20260227-v2 (2026-02-27) |
+| 4 | anthropic/claude-sonnet-4-6 | openrouter | 90.0% | 3026 | 5578 | 100.0% | 10 | next_run-20260228-234132 (2026-02-28) |
+| 5 | anthropic/claude-3.5-sonnet | openrouter | 90.0% | 5264 | 7457 | 100.0% | 10 | validated-20260227-v2 (2026-02-27) |
+| 6 | qwen/qwen3-1.7b | local | 85.7% | 1209 | 3780 | 93.3% | 7 | openrouter_small3 (2026-02-26) |
+| 7 | mistralai/ministral-3b-2512 | openrouter | 80.0% | 785 | 2043 | 95.5% | 10 | validated-20260227-v2 (2026-02-27) |
+| 8 | anthropic/claude-haiku-4-5 | openrouter | 80.0% | 2010 | 3754 | 90.9% | 10 | next_run-20260228-234132 (2026-02-28) |
+| 9 | qwen/qwen3-8b | local | 71.4% | 1641 | 7059 | 86.7% | 7 | openrouter_small3 (2026-02-26) |
+| 10 | google/gemini-2.5-flash | openrouter | 60.0% | 3304 | 12153 | 90.9% | 10 | validated-20260227 (2026-02-27) |
+| 11 | llama3.2:3b | local_server | 50.0% | 969 | 2665 | 81.8% | 10 | ollama_models-20260301-115348 (2026-03-01) |
+| 12 | deepseek/deepseek-chat | openrouter | 42.9% | 4288 | 5537 | 86.7% | 7 | full_all-20260226-180616 (2026-02-26) |
+| 13 | meta-llama/llama-3.1-8b-instruct | openrouter | 42.9% | 7615 | 14869 | 86.7% | 7 | full_all-with-smalltoolcall-20260226-184414 (2026-02-26) |
+| 14 | mistral-nemo:latest | local_server | 40.0% | 7093 | 17414 | 68.2% | 10 | validated-20260227-v2 (2026-02-27) |
+| 15 | qwen3-vl:8b | local_server | 30.0% | 20257 | 31637 | 77.3% | 10 | ollama_models-20260301-115348 (2026-03-01) |
+| 16 | minimax/minimax-01 | openrouter | 28.6% | 1946 | 5779 | 60.0% | 7 | full_remote-20260226-175045 (2026-02-26) |
+| 17 | qwen/qwen-2.5-7b-instruct | openrouter | 28.6% | 2987 | 4703 | 86.7% | 7 | full_all-with-smalltoolcall-20260226-184414 (2026-02-26) |
+| 18 | google/gemini-2.0-flash-lite-001 | openrouter | 14.3% | 852 | 1847 | 53.3% | 7 | full_all-20260226-180616 (2026-02-26) |
+| 19 | phi4-mini:latest | local_server | 10.0% | 647 | 3494 | 0.0% | 10 | ollama_models-20260301-115348 (2026-03-01) |
+| 20 | gemma3:4b | local_server | 10.0% | 1754 | 19886 | 0.0% | 10 | ollama_models-20260228-112957 (2026-02-28) |
+| 21 | ibm-granite/granite-4.0-h-micro | openrouter | 0.0% | 24 | 78 | 100.0% | 7 | full_all-with-smalltoolcall-20260226-184414 (2026-02-26) |
+| 22 | deepseek-r1:1.5b | local_server | 0.0% | 30 | 50 | 0.0% | 10 | ollama_models-20260228-122039 (2026-02-28) |
+| 23 | ministral-3b | local_server | 0.0% | 33 | 57 | 0.0% | 10 | ollama_models-20260228-112126 (2026-02-28) |
+| 24 | mistralai/mistral-small-3.1-24b-instruct:free | openrouter | 0.0% | 69 | 231 | 0.0% | 7 | latest (2026-02-26) |
+
+## By Provider
+
+### Local / On-Device
+
+| Model | Provider | Success% | Avg ms | Tool Sel% | Scenarios |
+|---|---|---:|---:|---:|---:|
+| qwen/qwen3-1.7b | local | 85.7% | 1209 | 93.3% | 7 |
+| qwen/qwen3-8b | local | 71.4% | 1641 | 86.7% | 7 |
+| llama3.2:3b | local_server | 50.0% | 969 | 81.8% | 10 |
+| mistral-nemo:latest | local_server | 40.0% | 7093 | 68.2% | 10 |
+| qwen3-vl:8b | local_server | 30.0% | 20257 | 77.3% | 10 |
+| phi4-mini:latest | local_server | 10.0% | 647 | 0.0% | 10 |
+| gemma3:4b | local_server | 10.0% | 1754 | 0.0% | 10 |
+| deepseek-r1:1.5b | local_server | 0.0% | 30 | 0.0% | 10 |
+| ministral-3b | local_server | 0.0% | 33 | 0.0% | 10 |
+
+### Cloud (OpenRouter)
+
+| Model | Provider | Success% | Avg ms | Tool Sel% | Scenarios |
+|---|---|---:|---:|---:|---:|
+| google/gemini-2.5-flash-lite | openrouter | 100.0% | 910 | 100.0% | 10 |
+| google/gemini-2.5-pro | openrouter | 100.0% | 4900 | 100.0% | 10 |
+| openai/gpt-4o-mini | openrouter | 90.0% | 1880 | 95.5% | 10 |
+| anthropic/claude-sonnet-4-6 | openrouter | 90.0% | 3026 | 100.0% | 10 |
+| anthropic/claude-3.5-sonnet | openrouter | 90.0% | 5264 | 100.0% | 10 |
+| mistralai/ministral-3b-2512 | openrouter | 80.0% | 785 | 95.5% | 10 |
+| anthropic/claude-haiku-4-5 | openrouter | 80.0% | 2010 | 90.9% | 10 |
+| google/gemini-2.5-flash | openrouter | 60.0% | 3304 | 90.9% | 10 |
+| deepseek/deepseek-chat | openrouter | 42.9% | 4288 | 86.7% | 7 |
+| meta-llama/llama-3.1-8b-instruct | openrouter | 42.9% | 7615 | 86.7% | 7 |
+| minimax/minimax-01 | openrouter | 28.6% | 1946 | 60.0% | 7 |
+| qwen/qwen-2.5-7b-instruct | openrouter | 28.6% | 2987 | 86.7% | 7 |
+| google/gemini-2.0-flash-lite-001 | openrouter | 14.3% | 852 | 53.3% | 7 |
+| ibm-granite/granite-4.0-h-micro | openrouter | 0.0% | 24 | 100.0% | 7 |
+| mistralai/mistral-small-3.1-24b-instruct:free | openrouter | 0.0% | 69 | 0.0% | 7 |
+
+## Runs Index
+
+All published runs included in this leaderboard.
+
+| Run | Started | Models | Scenarios |
+|---|---|---:|---:|
+| full_all-20260226-180616 | 2026-02-26 | 16 | 7 |
+| full_all-with-smalltoolcall-20260226-184414 | 2026-02-26 | 20 | 7 |
+| full_remote-20260226-175045 | 2026-02-26 | 8 | 7 |
+| latest | 2026-02-26 | 2 | 7 |
+| local-qwen-qwen3-8b-20260301-004137 | 2026-03-01 | 1 | 10 |
+| ministral-cross-provider | 2026-02-26 | 2 | 7 |
+| next_run-20260228-234132 | 2026-02-28 | 11 | 10 |
+| next_run-win32-native | 2026-02-28 | 10 | 10 |
+| ollama_models-20260228-111949 | 2026-02-28 | 6 | 10 |
+| ollama_models-20260228-112126 | 2026-02-28 | 6 | 10 |
+| ollama_models-20260228-112957 | 2026-02-28 | 6 | 10 |
+| ollama_models-20260228-114350 | 2026-02-28 | 6 | 10 |
+| ollama_models-20260228-120801 | 2026-02-28 | 5 | 10 |
+| ollama_models-20260228-122039 | 2026-02-28 | 5 | 10 |
+| ollama_models-20260228-122743 | 2026-02-28 | 5 | 10 |
+| ollama_models-20260301-115348 | 2026-03-01 | 6 | 10 |
+| ollama_models-win32-native | 2026-02-28 | 5 | 10 |
+| openrouter_small3 | 2026-02-26 | 18 | 7 |
+| schema-variants-20260227 | 2026-02-27 | 6 | 10 |
+| tool-profiles-20260227 | 2026-02-27 | 8 | 10 |
+| validated-20260227 | 2026-02-27 | 16 | 10 |
+| validated-20260227-v2 | 2026-02-27 | 16 | 10 |
+| validated-20260227-v3 | 2026-02-27 | 11 | 10 |
+| validated-20260227-v3-fixed | 2026-02-27 | 11 | 10 |
+| validated-20260227-v3-schemas | 2026-02-27 | 11 | 10 |

--- a/benchmarks/published/pipeline_leaderboard.md
+++ b/benchmarks/published/pipeline_leaderboard.md
@@ -1,9 +1,9 @@
 # TalkBot End-to-End Pipeline Leaderboard
 
-- Generated: 2026-03-01T20:19:17Z
+- Generated: 2026-03-01T21:50:32Z
 - STT configs: 2
 - TTS configs: 1
-- LLM models: 6
+- LLM models: 24
 
 ```
 TTFA = STT_ms + LLM_ms + TTS_ms
@@ -26,12 +26,30 @@ All values are averages over benchmark runs on this machine.
 
 | Model | Provider | Success% | Avg ms | Tool Sel% |
 |---|---|---:|---:|---:|
+| google/gemini-2.5-flash-lite | openrouter | 100.0% | 910 | 100.0% |
+| google/gemini-2.5-pro | openrouter | 100.0% | 4900 | 100.0% |
+| openai/gpt-4o-mini | openrouter | 90.0% | 1880 | 95.5% |
+| anthropic/claude-3.5-sonnet | openrouter | 90.0% | 7073 | 100.0% |
+| anthropic/claude-sonnet-4-6 | openrouter | 90.0% | 3026 | 100.0% |
+| qwen/qwen3-1.7b | local | 85.7% | 1582 | 93.3% |
+| mistralai/ministral-3b-2512 | openrouter | 80.0% | 785 | 95.5% |
+| anthropic/claude-haiku-4-5 | openrouter | 80.0% | 2010 | 90.9% |
+| qwen/qwen3-8b | local | 71.4% | 1867 | 86.7% |
+| google/gemini-2.5-flash | openrouter | 60.0% | 3304 | 90.9% |
 | llama3.2:3b | local_server | 50.0% | 969 | 81.8% |
-| mistral-nemo:latest | local_server | 30.0% | 3383 | 72.7% |
+| deepseek/deepseek-chat | openrouter | 42.9% | 4288 | 86.7% |
+| meta-llama/llama-3.1-8b-instruct | openrouter | 42.9% | 7615 | 86.7% |
+| mistral-nemo:latest | local_server | 40.0% | 7093 | 68.2% |
 | qwen3-vl:8b | local_server | 30.0% | 20257 | 77.3% |
-| phi4-mini:latest | local_server | 10.0% | 647 | 0.0% |
-| gemma3:4b | local_server | 0.0% | 625 | 0.0% |
-| deepseek-r1:1.5b | local_server | 0.0% | 2221 | 0.0% |
+| minimax/minimax-01 | openrouter | 28.6% | 2168 | 66.7% |
+| qwen/qwen-2.5-7b-instruct | openrouter | 28.6% | 2987 | 86.7% |
+| google/gemini-2.0-flash-lite-001 | openrouter | 14.3% | 852 | 53.3% |
+| gemma3:4b | local_server | 10.0% | 1754 | 0.0% |
+| phi4-mini:latest | local_server | 10.0% | 3304 | 0.0% |
+| ibm-granite/granite-4.0-h-micro | openrouter | 0.0% | 24 | 100.0% |
+| mistralai/mistral-small-3.1-24b-instruct:free | openrouter | 0.0% | 69 | 0.0% |
+| ministral-3b | local_server | 0.0% | 3159 | 0.0% |
+| deepseek-r1:1.5b | local_server | 0.0% | 35 | 0.0% |
 
 ### TTS
 
@@ -46,24 +64,60 @@ Sorted by TTFA ascending (fastest first).
 
 | STT | LLM | TTS | STT ms | LLM ms | TTS ms | **TTFA ms** | LLM Success% |
 |---|---|---|---:|---:|---:|---:|---:|
-| tiny.en/int8/cpu | gemma3:4b | kittentts/(default) | 312 | 625 | 1524 | **2461** | 0.0% |
-| tiny.en/int8/cpu | phi4-mini:latest | kittentts/(default) | 312 | 647 | 1524 | **2483** | 10.0% |
+| tiny.en/int8/cpu | ibm-granite/granite-4.0-h-micro | kittentts/(default) | 312 | 24 | 1524 | **1859** | 0.0% |
+| tiny.en/int8/cpu | deepseek-r1:1.5b | kittentts/(default) | 312 | 35 | 1524 | **1871** | 0.0% |
+| tiny.en/int8/cpu | mistralai/mistral-small-3.1-24b-instruct:free | kittentts/(default) | 312 | 69 | 1524 | **1905** | 0.0% |
+| tiny.en/int8/cpu | mistralai/ministral-3b-2512 | kittentts/(default) | 312 | 785 | 1524 | **2621** | 80.0% |
+| tiny.en/int8/cpu | google/gemini-2.0-flash-lite-001 | kittentts/(default) | 312 | 852 | 1524 | **2688** | 14.3% |
+| tiny.en/int8/cpu | google/gemini-2.5-flash-lite | kittentts/(default) | 312 | 910 | 1524 | **2746** | 100.0% |
 | tiny.en/int8/cpu | llama3.2:3b | kittentts/(default) | 312 | 969 | 1524 | **2805** | 50.0% |
-| tiny.en/int8/cpu | deepseek-r1:1.5b | kittentts/(default) | 312 | 2221 | 1524 | **4057** | 0.0% |
-| small.en/int8/cpu | gemma3:4b | kittentts/(default) | 1991 | 625 | 1524 | **4140** | 0.0% |
-| small.en/int8/cpu | phi4-mini:latest | kittentts/(default) | 1991 | 647 | 1524 | **4162** | 10.0% |
+| tiny.en/int8/cpu | qwen/qwen3-1.7b | kittentts/(default) | 312 | 1582 | 1524 | **3418** | 85.7% |
+| small.en/int8/cpu | ibm-granite/granite-4.0-h-micro | kittentts/(default) | 1991 | 24 | 1524 | **3539** | 0.0% |
+| small.en/int8/cpu | deepseek-r1:1.5b | kittentts/(default) | 1991 | 35 | 1524 | **3550** | 0.0% |
+| small.en/int8/cpu | mistralai/mistral-small-3.1-24b-instruct:free | kittentts/(default) | 1991 | 69 | 1524 | **3584** | 0.0% |
+| tiny.en/int8/cpu | gemma3:4b | kittentts/(default) | 312 | 1754 | 1524 | **3590** | 10.0% |
+| tiny.en/int8/cpu | qwen/qwen3-8b | kittentts/(default) | 312 | 1867 | 1524 | **3703** | 71.4% |
+| tiny.en/int8/cpu | openai/gpt-4o-mini | kittentts/(default) | 312 | 1880 | 1524 | **3716** | 90.0% |
+| tiny.en/int8/cpu | anthropic/claude-haiku-4-5 | kittentts/(default) | 312 | 2010 | 1524 | **3846** | 80.0% |
+| tiny.en/int8/cpu | minimax/minimax-01 | kittentts/(default) | 312 | 2168 | 1524 | **4004** | 28.6% |
+| small.en/int8/cpu | mistralai/ministral-3b-2512 | kittentts/(default) | 1991 | 785 | 1524 | **4300** | 80.0% |
+| small.en/int8/cpu | google/gemini-2.0-flash-lite-001 | kittentts/(default) | 1991 | 852 | 1524 | **4367** | 14.3% |
+| small.en/int8/cpu | google/gemini-2.5-flash-lite | kittentts/(default) | 1991 | 910 | 1524 | **4425** | 100.0% |
 | small.en/int8/cpu | llama3.2:3b | kittentts/(default) | 1991 | 969 | 1524 | **4484** | 50.0% |
-| tiny.en/int8/cpu | mistral-nemo:latest | kittentts/(default) | 312 | 3383 | 1524 | **5219** | 30.0% |
-| small.en/int8/cpu | deepseek-r1:1.5b | kittentts/(default) | 1991 | 2221 | 1524 | **5736** | 0.0% |
-| small.en/int8/cpu | mistral-nemo:latest | kittentts/(default) | 1991 | 3383 | 1524 | **6898** | 30.0% |
+| tiny.en/int8/cpu | qwen/qwen-2.5-7b-instruct | kittentts/(default) | 312 | 2987 | 1524 | **4823** | 28.6% |
+| tiny.en/int8/cpu | anthropic/claude-sonnet-4-6 | kittentts/(default) | 312 | 3026 | 1524 | **4862** | 90.0% |
+| tiny.en/int8/cpu | ministral-3b | kittentts/(default) | 312 | 3159 | 1524 | **4995** | 0.0% |
+| small.en/int8/cpu | qwen/qwen3-1.7b | kittentts/(default) | 1991 | 1582 | 1524 | **5097** | 85.7% |
+| tiny.en/int8/cpu | phi4-mini:latest | kittentts/(default) | 312 | 3304 | 1524 | **5140** | 10.0% |
+| tiny.en/int8/cpu | google/gemini-2.5-flash | kittentts/(default) | 312 | 3304 | 1524 | **5140** | 60.0% |
+| small.en/int8/cpu | gemma3:4b | kittentts/(default) | 1991 | 1754 | 1524 | **5269** | 10.0% |
+| small.en/int8/cpu | qwen/qwen3-8b | kittentts/(default) | 1991 | 1867 | 1524 | **5382** | 71.4% |
+| small.en/int8/cpu | openai/gpt-4o-mini | kittentts/(default) | 1991 | 1880 | 1524 | **5395** | 90.0% |
+| small.en/int8/cpu | anthropic/claude-haiku-4-5 | kittentts/(default) | 1991 | 2010 | 1524 | **5525** | 80.0% |
+| small.en/int8/cpu | minimax/minimax-01 | kittentts/(default) | 1991 | 2168 | 1524 | **5683** | 28.6% |
+| tiny.en/int8/cpu | deepseek/deepseek-chat | kittentts/(default) | 312 | 4288 | 1524 | **6124** | 42.9% |
+| small.en/int8/cpu | qwen/qwen-2.5-7b-instruct | kittentts/(default) | 1991 | 2987 | 1524 | **6502** | 28.6% |
+| small.en/int8/cpu | anthropic/claude-sonnet-4-6 | kittentts/(default) | 1991 | 3026 | 1524 | **6541** | 90.0% |
+| small.en/int8/cpu | ministral-3b | kittentts/(default) | 1991 | 3159 | 1524 | **6674** | 0.0% |
+| tiny.en/int8/cpu | google/gemini-2.5-pro | kittentts/(default) | 312 | 4900 | 1524 | **6736** | 100.0% |
+| small.en/int8/cpu | phi4-mini:latest | kittentts/(default) | 1991 | 3304 | 1524 | **6819** | 10.0% |
+| small.en/int8/cpu | google/gemini-2.5-flash | kittentts/(default) | 1991 | 3304 | 1524 | **6819** | 60.0% |
+| small.en/int8/cpu | deepseek/deepseek-chat | kittentts/(default) | 1991 | 4288 | 1524 | **7803** | 42.9% |
+| small.en/int8/cpu | google/gemini-2.5-pro | kittentts/(default) | 1991 | 4900 | 1524 | **8415** | 100.0% |
+| tiny.en/int8/cpu | anthropic/claude-3.5-sonnet | kittentts/(default) | 312 | 7073 | 1524 | **8909** | 90.0% |
+| tiny.en/int8/cpu | mistral-nemo:latest | kittentts/(default) | 312 | 7093 | 1524 | **8929** | 40.0% |
+| tiny.en/int8/cpu | meta-llama/llama-3.1-8b-instruct | kittentts/(default) | 312 | 7615 | 1524 | **9451** | 42.9% |
+| small.en/int8/cpu | anthropic/claude-3.5-sonnet | kittentts/(default) | 1991 | 7073 | 1524 | **10588** | 90.0% |
+| small.en/int8/cpu | mistral-nemo:latest | kittentts/(default) | 1991 | 7093 | 1524 | **10608** | 40.0% |
+| small.en/int8/cpu | meta-llama/llama-3.1-8b-instruct | kittentts/(default) | 1991 | 7615 | 1524 | **11130** | 42.9% |
 | tiny.en/int8/cpu | qwen3-vl:8b | kittentts/(default) | 312 | 20257 | 1524 | **22093** | 30.0% |
 | small.en/int8/cpu | qwen3-vl:8b | kittentts/(default) | 1991 | 20257 | 1524 | **23772** | 30.0% |
 
 ## Recommended Configs
 
-**Fastest:** tiny.en/int8/cpu + gemma3:4b + kittentts/(default)  
-→ TTFA ~2461 ms | LLM success 0.0%
+**Fastest:** tiny.en/int8/cpu + ibm-granite/granite-4.0-h-micro + kittentts/(default)  
+→ TTFA ~1859 ms | LLM success 0.0%
 
 **Best balanced** (highest success within 1.5× min TTFA):  
-tiny.en/int8/cpu + llama3.2:3b + kittentts/(default)  
-→ TTFA ~2805 ms | LLM success 50.0%
+tiny.en/int8/cpu + google/gemini-2.5-flash-lite + kittentts/(default)  
+→ TTFA ~2746 ms | LLM success 100.0%

--- a/scripts/build_grand_leaderboard.py
+++ b/scripts/build_grand_leaderboard.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Grand Leaderboard Builder
+
+Scans all published LLM benchmark runs, finds the best result per model, and
+produces a single ranked summary table — the "leaderboard of leaderboards".
+
+Output: benchmarks/published/grand_leaderboard.md
+
+Usage:
+    uv run python scripts/build_grand_leaderboard.py
+    uv run python scripts/build_grand_leaderboard.py --runs-dir benchmarks/published/runs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve().parent
+    for candidate in [here, here.parent, here.parent.parent]:
+        if (candidate / "pyproject.toml").exists():
+            return candidate
+    return here.parent
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+def _load_all_runs(runs_dir: Path) -> list[dict]:
+    """Collect every model-run record from all results.json files under runs_dir."""
+    all_runs: list[dict] = []
+    for results_file in sorted(runs_dir.glob("*/results.json")):
+        run_name = results_file.parent.name
+        try:
+            data = json.loads(results_file.read_text(encoding="utf-8"))
+            scenario_count = data.get("scenario_count", 0)
+            started_at = data.get("started_at", "")
+            for run in data.get("runs", []):
+                if not isinstance(run, dict):
+                    continue
+                profile = run.get("profile") or {}
+                agg = run.get("aggregate") or {}
+                # Skip error/empty runs
+                if run.get("status") == "error" and not agg:
+                    continue
+                all_runs.append({
+                    "run_name": run_name,
+                    "started_at": started_at,
+                    "scenario_count": scenario_count,
+                    "model": profile.get("model", "unknown"),
+                    "provider": profile.get("provider", "unknown"),
+                    "success": agg.get("task_success_rate", 0.0),
+                    "avg_ms": agg.get("avg_turn_latency_ms", 0.0),
+                    "p95_ms": agg.get("p95_turn_latency_ms", 0.0),
+                    "tool_sel": agg.get("tool_selection_accuracy", 0.0),
+                    "arg_acc": agg.get("argument_accuracy", 0.0),
+                    "tokens_per_s": agg.get("tokens_per_second", 0.0),
+                    "scenario_passed": agg.get("scenario_passed", 0),
+                    "scenario_total": agg.get("scenario_count", scenario_count),
+                })
+        except Exception as exc:
+            print(f"  [warn] skip {run_name}: {exc}", file=sys.stderr)
+    return all_runs
+
+
+# ---------------------------------------------------------------------------
+# Best-per-model selector
+# ---------------------------------------------------------------------------
+
+def _best_per_model(all_runs: list[dict]) -> list[dict]:
+    """For each (model, provider) pair, keep the highest-success run.
+    Ties broken by: higher scenario_count first, then lower avg_ms.
+    """
+    best: dict[tuple, dict] = {}
+    for r in all_runs:
+        key = (r["model"], r["provider"])
+        if key not in best:
+            best[key] = r
+        else:
+            prev = best[key]
+            # Higher success wins
+            if r["success"] > prev["success"]:
+                best[key] = r
+            elif r["success"] == prev["success"]:
+                # More scenarios is more trustworthy
+                if r["scenario_count"] > prev["scenario_count"]:
+                    best[key] = r
+                elif r["scenario_count"] == prev["scenario_count"] and r["avg_ms"] < prev["avg_ms"]:
+                    best[key] = r
+    return list(best.values())
+
+
+# ---------------------------------------------------------------------------
+# Leaderboard builder
+# ---------------------------------------------------------------------------
+
+PROVIDER_ORDER = ["local_server", "local", "openrouter", "unknown"]
+
+
+def _provider_group(provider: str) -> str:
+    if provider in ("local_server", "local"):
+        return "Local / On-Device"
+    if provider == "openrouter":
+        return "Cloud (OpenRouter)"
+    return "Other"
+
+
+def build_grand_leaderboard(all_runs: list[dict]) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    best = _best_per_model(all_runs)
+    # Sort: success DESC, avg_ms ASC
+    best.sort(key=lambda r: (-r["success"], r["avg_ms"]))
+
+    # Stats
+    run_names = sorted({r["run_name"] for r in all_runs})
+    unique_models = len(best)
+    total_model_runs = len(all_runs)
+
+    lines = [
+        "# TalkBot Grand Leaderboard",
+        "",
+        f"- Generated: {now}",
+        f"- Published runs scanned: {len(run_names)}",
+        f"- Unique model × provider combos: {unique_models}",
+        f"- Total model-run records: {total_model_runs}",
+        "",
+        "Best result per model across **all** published benchmark runs.",
+        "Success% = fraction of scenarios where the model answered correctly.",
+        "",
+        "## All Models — Best Ever",
+        "",
+        "| # | Model | Provider | Success% | Avg ms | P95 ms | Tool Sel% | Scenarios | Best Run |",
+        "|---:|---|---|---:|---:|---:|---:|---:|---|",
+    ]
+
+    for rank, r in enumerate(best, 1):
+        run_date = r["started_at"][:10] if r["started_at"] else "?"
+        lines.append(
+            f"| {rank} "
+            f"| {r['model']} "
+            f"| {r['provider']} "
+            f"| {r['success']:.1%} "
+            f"| {r['avg_ms']:.0f} "
+            f"| {r['p95_ms']:.0f} "
+            f"| {r['tool_sel']:.1%} "
+            f"| {r['scenario_count']} "
+            f"| {r['run_name']} ({run_date}) "
+            f"|"
+        )
+
+    # --- Provider group breakdowns ---
+    lines += [
+        "",
+        "## By Provider",
+        "",
+    ]
+
+    groups: dict[str, list[dict]] = {}
+    for r in best:
+        g = _provider_group(r["provider"])
+        groups.setdefault(g, []).append(r)
+
+    for group_name in ["Local / On-Device", "Cloud (OpenRouter)", "Other"]:
+        members = groups.get(group_name)
+        if not members:
+            continue
+        members.sort(key=lambda r: (-r["success"], r["avg_ms"]))
+        lines += [
+            f"### {group_name}",
+            "",
+            "| Model | Provider | Success% | Avg ms | Tool Sel% | Scenarios |",
+            "|---|---|---:|---:|---:|---:|",
+        ]
+        for r in members:
+            lines.append(
+                f"| {r['model']} "
+                f"| {r['provider']} "
+                f"| {r['success']:.1%} "
+                f"| {r['avg_ms']:.0f} "
+                f"| {r['tool_sel']:.1%} "
+                f"| {r['scenario_count']} "
+                f"|"
+            )
+        lines.append("")
+
+    # --- Runs index ---
+    lines += [
+        "## Runs Index",
+        "",
+        "All published runs included in this leaderboard.",
+        "",
+        "| Run | Started | Models | Scenarios |",
+        "|---|---|---:|---:|",
+    ]
+    run_meta: dict[str, dict] = {}
+    for r in all_runs:
+        rn = r["run_name"]
+        if rn not in run_meta:
+            run_meta[rn] = {"started": r["started_at"][:10] if r["started_at"] else "?",
+                            "models": 0, "scenarios": r["scenario_count"]}
+        run_meta[rn]["models"] += 1
+
+    for run_name in sorted(run_meta):
+        m = run_meta[run_name]
+        lines.append(
+            f"| {run_name} "
+            f"| {m['started']} "
+            f"| {m['models']} "
+            f"| {m['scenarios']} "
+            f"|"
+        )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--runs-dir", default="benchmarks/published/runs",
+                        help="Directory containing run subdirectories "
+                             "(default: benchmarks/published/runs)")
+    parser.add_argument("--publish-dir", default="benchmarks/published",
+                        help="Output directory (default: benchmarks/published)")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    repo_root = _repo_root()
+
+    runs_dir = repo_root / args.runs_dir
+    publish_dir = repo_root / args.publish_dir
+    publish_dir.mkdir(parents=True, exist_ok=True)
+
+    if not runs_dir.exists():
+        print(f"Error: runs directory not found: {runs_dir}", file=sys.stderr)
+        return 1
+
+    all_runs = _load_all_runs(runs_dir)
+    print(f"Loaded {len(all_runs)} model-run records from {runs_dir.name}/")
+
+    if not all_runs:
+        print("No runs found — nothing to publish.", file=sys.stderr)
+        return 1
+
+    md = build_grand_leaderboard(all_runs)
+    out = publish_dir / "grand_leaderboard.md"
+    out.write_text(md, encoding="utf-8")
+    print(f"Written: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_pipeline_leaderboard.py
+++ b/scripts/build_pipeline_leaderboard.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """Pipeline TTFA Leaderboard Builder
 
-Reads accumulated STT and TTS result JSONs, reads LLM benchmark data from
-the published LLM leaderboard, and composes end-to-end TTFA estimates.
+Reads accumulated STT and TTS result JSONs, discovers LLM benchmark data from
+all published run directories, and composes end-to-end TTFA estimates.
 
 Output: benchmarks/published/pipeline_leaderboard.md
 
 Usage:
     uv run python scripts/build_pipeline_leaderboard.py
-    uv run python scripts/build_pipeline_leaderboard.py --llm-results benchmark_results/results.json
+    uv run python scripts/build_pipeline_leaderboard.py --llm-results benchmarks/published/runs/ollama_models-20260301-115348/results.json
 """
 
 from __future__ import annotations
@@ -53,16 +53,36 @@ def _load_tts_results(tts_dir: Path) -> list[dict]:
     return results
 
 
-def _load_llm_runs(llm_results_path: Path) -> list[dict]:
-    """Load LLM benchmark run aggregates from results.json."""
-    if not llm_results_path.exists():
+def _load_llm_runs(llm_source: Path) -> list[dict]:
+    """Load LLM benchmark run aggregates.
+
+    llm_source may be:
+    - A specific results.json file, or
+    - A directory containing run subdirectories (each with results.json).
+      Globs <llm_source>/*/results.json to discover all published runs.
+    """
+    if not llm_source.exists():
+        print(f"  [warn] LLM source not found: {llm_source}", file=sys.stderr)
         return []
-    try:
-        data = json.loads(llm_results_path.read_text(encoding="utf-8"))
-        return data.get("runs", [])
-    except Exception as exc:
-        print(f"  [warn] LLM: could not read {llm_results_path}: {exc}", file=sys.stderr)
-        return []
+
+    if llm_source.is_file():
+        paths = [llm_source]
+    else:
+        paths = sorted(llm_source.glob("*/results.json"))
+        if not paths:
+            print(f"  [warn] LLM: no results.json files found under {llm_source}", file=sys.stderr)
+            return []
+        print(f"  [llm] Discovered {len(paths)} run(s) under {llm_source.name}/")
+
+    runs: list[dict] = []
+    for path in paths:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            batch = data.get("runs", [])
+            runs.extend(batch)
+        except Exception as exc:
+            print(f"  [warn] LLM: could not read {path}: {exc}", file=sys.stderr)
+    return runs
 
 
 # ---------------------------------------------------------------------------
@@ -295,8 +315,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
                         help="STT results directory (default: benchmarks/stt_results)")
     parser.add_argument("--tts-dir", default="benchmarks/tts_results",
                         help="TTS results directory (default: benchmarks/tts_results)")
-    parser.add_argument("--llm-results", default="benchmark_results/results.json",
-                        help="LLM results.json path (default: benchmark_results/results.json)")
+    parser.add_argument("--llm-results", default="benchmarks/published/runs",
+                        help="LLM results.json file or published runs directory "
+                             "(default: benchmarks/published/runs)")
     parser.add_argument("--publish-dir", default="benchmarks/published",
                         help="Output directory (default: benchmarks/published)")
     return parser.parse_args(argv)
@@ -308,13 +329,13 @@ def main(argv: list[str] | None = None) -> int:
 
     stt_dir = repo_root / args.stt_dir
     tts_dir = repo_root / args.tts_dir
-    llm_path = repo_root / args.llm_results
+    llm_source = repo_root / args.llm_results
     publish_dir = repo_root / args.publish_dir
     publish_dir.mkdir(parents=True, exist_ok=True)
 
     stt_results = _load_stt_results(stt_dir)
     tts_results = _load_tts_results(tts_dir)
-    llm_runs = _load_llm_runs(llm_path)
+    llm_runs = _load_llm_runs(llm_source)
 
     print(f"Loaded: {len(stt_results)} STT runs, {len(tts_results)} TTS runs, {len(llm_runs)} LLM runs")
 


### PR DESCRIPTION
## Summary

- **Fix**: `build_pipeline_leaderboard.py` was reading from gitignored `benchmark_results/results.json` — changed default to glob all `benchmarks/published/runs/*/results.json`, so it works out-of-the-box from any clone
- **New**: `scripts/build_grand_leaderboard.py` — scans all 25 published runs (217 model-run records), deduplicates to best-ever per model, produces ranked table with provider breakdown and runs index
- **Updated**: `pipeline_leaderboard.md` now shows 24 models (was 6); best balanced config is now `tiny.en + gemini-2.5-flash-lite → 2746ms TTFA at 100% success`
- **New**: `benchmarks/published/grand_leaderboard.md` — top result: Gemini-2.5-Flash-Lite (100% success, 910ms), best local: qwen3-1.7b (85.7%, 1209ms)

## Stack issues also identified (not fixed here)

- `conversation_results/` uses a different schema (multi-turn dialogue) — not yet integrated into pipeline leaderboard
- First-turn warm-up latency inflates `avg_round_trip_ms` above `p95` in conversation results — should separate first-turn from steady-state reporting
- `coherence_score: 0.0` across all mistral-small conversation runs — needs investigation

## Test plan

- [ ] `uv run python scripts/build_grand_leaderboard.py` — verify 24 models, two provider sections
- [ ] `uv run python scripts/build_pipeline_leaderboard.py` — verify 24 LLM models loaded, best balanced = gemini-2.5-flash-lite
- [ ] Delete local `benchmark_results/results.json` and re-run pipeline leaderboard — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)