### PR TITLE
fix(tools): instruct get_list to narrate items in response

### DIFF
--- a/src/talkbot/tools.py
+++ b/src/talkbot/tools.py
@@ -809,7 +809,7 @@ TOOL_DEFINITIONS = {
         },
     },
     "get_list": {
-        "description": "Get all items on a named list. Always call this tool to check list contents — do not answer from conversation context.",
+        "description": "Get all items on a named list. Always call this tool to check list contents — do not answer from conversation context. After calling, read back every item in your response.",
         "parameters": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Problem

`get_list` was called correctly but the model responded with a generic acknowledgment ("The packing list is now complete.") instead of reading back the items. For a voice assistant, the user needs to hear the list contents spoken aloud.

## Fix

Added `"After calling, read back every item in your response."` to the `get_list` tool description (standard schema).

## Validation

Ran `list_multistep_packing` scenario against `qwen3.5-0.8b-q8_0` via llama-server. Turn 2 response before:
> "The packing list is now complete."

Turn 2 response after:
> "The packing list now includes: socks, charger"

Scenario: 100% pass. Was previously non-deterministic (~50% pass rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)