### PR TITLE
fix(tools+tests): list_all_lists narration + sync fake client to scenario fix

### DIFF
--- a/src/talkbot/tools.py
+++ b/src/talkbot/tools.py
@@ -852,7 +852,7 @@ TOOL_DEFINITIONS = {
         },
     },
     "list_all_lists": {
-        "description": "Show all named lists and their contents",
+        "description": "Show all named lists and their contents. Read back every list name and its items in your response.",
         "parameters": {"type": "object", "properties": {}, "required": []},
     },
     "remember": {
@@ -939,7 +939,7 @@ TOOL_DEFINITION_VARIANTS: dict[str, dict[str, dict]] = {
                                "parameters": TOOL_DEFINITIONS["get_list"]["parameters"]},
         "create_list":        {"description": "Create a new empty named list.",
                                "parameters": TOOL_DEFINITIONS["create_list"]["parameters"]},
-        "list_all_lists":     {"description": "Show all lists and their contents.",
+        "list_all_lists":     {"description": "Show all lists and their contents. Read back every list name and its items in your response.",
                                "parameters": TOOL_DEFINITIONS["list_all_lists"]["parameters"]},
     },
     "examples": {

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -93,7 +93,7 @@ class FakeBenchClient:
             return self.tools["add_to_list"](items="check the timer", list_name="reminders")
         if "what's today's date" in lower:
             return self.tools["get_current_date"]()
-        if "cancel timer 99" in lower:
+        if "cancel timer #99" in lower:
             self.tools["set_timer"](seconds=0)  # produces error trace for tool_call_error_rate
             return self.tools["cancel_timer"](timer_id="99")
         if "list my timers so i can see" in lower:


### PR DESCRIPTION
## Changes

**`src/talkbot/tools.py`** — add narration instruction to `list_all_lists` (both `TOOL_DEFINITIONS` and `_SCHEMA_VARIANTS["standard"]`):
> "Read back every list name and its items in your response."

Mirrors the `get_list` fix from PR #31. For a voice assistant, "What lists do you have?" should produce a spoken enumeration of all lists, not a silent tool call with a generic acknowledgment.

**`tests/test_benchmark.py`** — update `FakeBenchClient` recovery check:
- `"cancel timer 99"` → `"cancel timer #99"` to match the scenario wording fixed in PR #27
- Without this, `task_success_rate` in the fake-client test dropped from 1.0 to 0.9 (the fake client returned `"Unhandled"` for the recovery turn)

## Note

`list_basics` still fails on `qwen3.5-0.8b-q8_0` — the model adds milk to `shopping` instead of `grocery` (turn 1 list name inconsistency), then ignores the `list_all_lists` result in its turn 2 response. This is a genuine 0.8b quality limitation, not a scenario or tool description bug. Canonical result remains 90%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)