### PR TITLE
feat: add prompt preset review and benchmark workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A talking AI assistant with local-first LLM + TTS defaults, plus optional OpenRo
 ## Features
 
 - **AI Chat**: Local llama-server provider by default, with OpenRouter optional
-- **Agent Personality**: Set a system prompt once via `TALKBOT_AGENT_PROMPT` env var or the GUI Prompt tab — all commands pick it up automatically
+- **Agent Personality**: Set a system prompt once via `TALKBOT_AGENT_PROMPT_FILE` or `TALKBOT_AGENT_PROMPT`; prompt presets are cataloged under `prompts/`
 - **21 Built-in Tools**: Calculator, timers, reminders, web search, shopping lists, memory/preferences, dice, and more
 - **Timers & Reminders**: `set_timer` for simple countdowns; `set_reminder` for custom spoken messages — cancellable, with live GUI display
 - **Persistent Lists & Memory**: Named lists and user preferences survive across sessions (`~/.talkbot/`)
@@ -265,10 +265,9 @@ TALKBOT_ENABLE_THINKING=0
 TALKBOT_DEFAULT_TTS_BACKEND=kittentts
 
 # Agent personality (optional) — applied to all CLI commands and GUI Prompt tab
-# TALKBOT_AGENT_PROMPT="You are a voice-first assistant with access to tools. Be extremely brief."
-# Keep TALKBOT_AGENT_PROMPT single-line in .env.
-# For multiline markdown prompts, store them in a file (for example: prompts/agent.md)
-# and pass with --system "$(cat prompts/agent.md)".
+# TALKBOT_AGENT_PROMPT_FILE=./prompts/tool_reliability.md
+# Backward-compatible alternative:
+# TALKBOT_AGENT_PROMPT="You are a brief voice assistant."
 ```
 
 Optional remote provider:
@@ -280,6 +279,45 @@ OPENROUTER_API_KEY=your_api_key_here
 Get OpenRouter keys at [OpenRouter](https://openrouter.ai/keys).
 
 The application automatically loads environment variables from `.env` using python-dotenv.
+Prompt presets can live in `prompts/`; switch between them by changing `TALKBOT_AGENT_PROMPT_FILE`.
+
+### Prompt Review Workflow
+
+Prompt files are tracked in [`prompts/catalog.json`](prompts/catalog.json) with:
+- a stable preset name
+- a short summary and review notes
+- declared goals for linting
+- the benchmark/UAT scenarios that should be used to review the prompt
+
+Review the presets and lint them:
+
+```bash
+uv run python scripts/review_prompts.py
+```
+
+Run the prompt review scenarios as a benchmark for each preset:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run python scripts/review_prompts.py \
+  --run-benchmark \
+  --provider local_server \
+  --model qwen3.5-0.8b-q8_0 \
+  --local-server-url http://127.0.0.1:8000/v1
+```
+
+If the review script reports prompt errors, fix those before trusting benchmark results. The current lint checks catch things like missing review scenarios, missing tool/voice guidance, and references to tools that do not exist.
+
+For ad hoc benchmark A/B runs on a single prompt preset, `scripts/benchmark_conversations.py` also supports:
+
+```bash
+uv run python scripts/benchmark_conversations.py \
+  --prompt-preset tool_reliability \
+  --provider local_server \
+  --model qwen3.5-0.8b-q8_0 \
+  --local-server-url http://127.0.0.1:8000/v1
+```
+
+The generated leaderboard now includes a `Prompt` column on run tables plus a `Prompt Impact` section that compares prompt variants on the same model/runtime slice.
 
 ### Default Runtime Behavior
 
@@ -352,9 +390,15 @@ talkbot say --backend kittentts
 talkbot say --tools
 talkbot say --tools --system "You are a brief voice assistant."
 
-# Or set TALKBOT_AGENT_PROMPT in .env / env and omit --system
-export TALKBOT_AGENT_PROMPT="You are a brief voice assistant."
+# Or set TALKBOT_AGENT_PROMPT_FILE / TALKBOT_AGENT_PROMPT in .env / env and omit --system
+export TALKBOT_AGENT_PROMPT_FILE=./prompts/tool_reliability.md
 talkbot say --tools
+```
+
+List and review prompt presets before changing the default:
+
+```bash
+uv run python scripts/review_prompts.py --preset tool_reliability
 ```
 
 #### Local Voice Chat (Half-Duplex, VAD-Gated)
@@ -530,7 +574,7 @@ The GUI features a modern dark theme with:
 - **Use Tools toggle** — Enable all 21 built-in tools for chat and voice
 - **Timers tab** — Live countdown display, updates every second
 - **Lists tab** — Live view of all named lists, updates every 2 seconds
-- **Prompt tab** — Edit the agent system prompt live; pre-populated from `TALKBOT_AGENT_PROMPT` on launch
+- **Prompt tab** — Edit the agent system prompt live; pre-populated from `TALKBOT_AGENT_PROMPT_FILE` or `TALKBOT_AGENT_PROMPT` on launch
 
 ```bash
 uv run talkbot-gui
@@ -581,7 +625,19 @@ uv run python scripts/benchmark_conversations.py \
   --runner-label my-machine
 ```
 
+Matrix profiles can also set `prompt_preset`, `prompt_catalog`, or `prompt_file` so the same model can be benchmarked across multiple prompt variants as a first-class comparison.
+
 See `benchmarks/model_matrix.example.json` for the current active model set and `benchmarks/decision_strategy.md` for hardware-specific decisions.
+
+### Run a prompt matrix
+
+```bash
+uv run python scripts/benchmark_conversations.py \
+  --matrix benchmarks/model_matrix.prompts.example.json \
+  --runner-label my-machine
+```
+
+Use `benchmarks/model_matrix.prompts.example.json` when you want prompt A/B comparisons on the same model/runtime slice. The resulting leaderboard will populate the `Prompt Impact` section directly.
 
 ### Benchmark outputs
 
@@ -639,6 +695,7 @@ talkbot/
 │   └── download_model.py           # GGUF downloader
 ├── benchmarks/
 │   ├── model_matrix.example.json   # Active benchmark model set
+│   ├── model_matrix.prompts.example.json # Prompt A/B matrix example
 │   ├── decision_strategy.md        # Hardware-specific model decisions
 │   └── published/                  # Published benchmark results
 │       ├── latest/                 # Current best result

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -227,4 +227,5 @@ See `benchmarks/LESSONS_LEARNED.md` for accumulated observations from all runs:
 | `decision_strategy.md` | Hardware-specific model retirement decisions |
 | `LESSONS_LEARNED.md` | Accumulated debugging and tuning findings |
 | `model_matrix.example.json` | Active model set for benchmark runs |
+| `model_matrix.prompts.example.json` | Prompt A/B matrix for prompt impact runs |
 | `evaluation_values.json` | Rubric weights and scoring parameters |

--- a/benchmarks/model_matrix.prompts.example.json
+++ b/benchmarks/model_matrix.prompts.example.json
@@ -1,0 +1,79 @@
+{
+  "benchmark": {
+    "schema_version": "2026.1",
+    "values_file": "benchmarks/evaluation_values.json",
+    "rubric": {
+      "version": "2026.prompts.v1",
+      "weights": {
+        "task_success_rate": 0.35,
+        "tool_selection_accuracy": 0.2,
+        "argument_accuracy": 0.15,
+        "recovery_success_rate": 0.1,
+        "multistep_success_rate": 0.1,
+        "robustness_success_rate": 0.05,
+        "context_success_rate": 0.05
+      },
+      "penalties": {
+        "latency_ms_multiplier": 0.002,
+        "memory_mb_multiplier": 0.002,
+        "tool_error_rate_multiplier": 20.0,
+        "model_error_rate_multiplier": 30.0
+      }
+    },
+    "context_analysis": {
+      "near_peak_ratio": 0.95,
+      "dropoff_ratio": 0.9
+    }
+  },
+  "_comment": "Prompt A/B matrix: hold provider/model/runtime constant and vary only prompt_preset. Use with the leaderboard Prompt Impact section.",
+  "profiles": [
+    {
+      "name": "llama-server-qwen35-0.8b-agent",
+      "provider": "local_server",
+      "local_server_url": "http://127.0.0.1:8000/v1",
+      "local_model_path": "models/qwen3.5-0.8b-q8_0.gguf",
+      "model": "qwen3.5-0.8b-q8_0",
+      "prompt_preset": "agent",
+      "enable_thinking": false,
+      "use_tools": true,
+      "tool_schema_variant": "standard",
+      "max_tokens": 512,
+      "temperature": 0.0,
+      "env": {
+        "TALKBOT_LOCAL_DIRECT_TOOL_ROUTING": "1"
+      }
+    },
+    {
+      "name": "llama-server-qwen35-0.8b-tool-benchmark",
+      "provider": "local_server",
+      "local_server_url": "http://127.0.0.1:8000/v1",
+      "local_model_path": "models/qwen3.5-0.8b-q8_0.gguf",
+      "model": "qwen3.5-0.8b-q8_0",
+      "prompt_preset": "tool_benchmark",
+      "enable_thinking": false,
+      "use_tools": true,
+      "tool_schema_variant": "standard",
+      "max_tokens": 512,
+      "temperature": 0.0,
+      "env": {
+        "TALKBOT_LOCAL_DIRECT_TOOL_ROUTING": "1"
+      }
+    },
+    {
+      "name": "llama-server-qwen35-0.8b-tool-reliability",
+      "provider": "local_server",
+      "local_server_url": "http://127.0.0.1:8000/v1",
+      "local_model_path": "models/qwen3.5-0.8b-q8_0.gguf",
+      "model": "qwen3.5-0.8b-q8_0",
+      "prompt_preset": "tool_reliability",
+      "enable_thinking": false,
+      "use_tools": true,
+      "tool_schema_variant": "standard",
+      "max_tokens": 512,
+      "temperature": 0.0,
+      "env": {
+        "TALKBOT_LOCAL_DIRECT_TOOL_ROUTING": "1"
+      }
+    }
+  ]
+}

--- a/prompts/catalog.json
+++ b/prompts/catalog.json
@@ -1,0 +1,45 @@
+{
+  "prompts": [
+    {
+      "name": "agent",
+      "file": "agent.md",
+      "summary": "General voice-first preset for interactive CLI and GUI use.",
+      "goals": ["voice", "tool_first"],
+      "scenarios": [
+        "utility_time_date",
+        "list_basics",
+        "memory_persistent_strict",
+        "timer_basics"
+      ],
+      "review_notes": "Use for day-to-day assistant behavior, not benchmark-only runs."
+    },
+    {
+      "name": "tool_benchmark",
+      "file": "tool_benchmark.md",
+      "summary": "Benchmark preset focused on reliable tool selection and retry behavior.",
+      "goals": ["tool_first", "stateful_tools", "exact_args"],
+      "scenarios": [
+        "utility_time_date",
+        "list_basics",
+        "memory_persistent_strict",
+        "recovery_timer_retry",
+        "timer_basics"
+      ],
+      "review_notes": "Intended for benchmark and regression runs that stress tool routing."
+    },
+    {
+      "name": "tool_reliability",
+      "file": "tool_reliability.md",
+      "summary": "Minimal preset for local tool-routing smoke tests and UAT.",
+      "goals": ["tool_first", "stateful_tools", "exact_args"],
+      "scenarios": [
+        "utility_time_date",
+        "list_basics",
+        "memory_persistent_strict",
+        "recovery_timer_retry",
+        "timer_basics"
+      ],
+      "review_notes": "Short on purpose; compare against richer prompts during review."
+    }
+  ]
+}

--- a/prompts/tool_benchmark.md
+++ b/prompts/tool_benchmark.md
@@ -13,7 +13,7 @@ Rules:
    - stop/cancel -> `cancel_timer`
 6. For list tasks:
    - create -> `create_list`
-   - add -> `add_to_list` or `add_items_to_list`
+   - add -> `add_to_list`
    - show all -> `list_all_lists`
 7. Use exact parameter names expected by tools. Do not invent extra parameters.
 8. If a tool returns an error, adjust the next tool call arguments and retry once.

--- a/prompts/tool_reliability.md
+++ b/prompts/tool_reliability.md
@@ -1,0 +1,1 @@
+You are being evaluated for tool-use reliability. Always call tools when a request can be solved via tools. For memory/list/timer requests, call tools first and do not answer from chat memory alone. Use exact tool parameter names only.

--- a/scripts/benchmark_conversations.py
+++ b/scripts/benchmark_conversations.py
@@ -28,6 +28,7 @@ from talkbot.benchmark import (
 )
 from talkbot.benchmark_publish import publish_benchmark_results
 from talkbot.judge import DEFAULT_JUDGE_MODEL, JudgeConfig, LLMJudge, estimate_judge_cost
+from talkbot.prompting import DEFAULT_PROMPT_CATALOG, resolve_prompt_reference
 
 
 # ---------------------------------------------------------------------------
@@ -171,11 +172,12 @@ def _default_profile_from_args(args: argparse.Namespace) -> BenchmarkProfile:
     if args.n_ctx is not None:
         env["TALKBOT_LOCAL_N_CTX"] = str(args.n_ctx)
 
-    system_prompt: str | None = None
-    if args.system_prompt_file:
-        system_prompt = Path(args.system_prompt_file).read_text(encoding="utf-8").strip()
-    elif args.system_prompt:
-        system_prompt = args.system_prompt.strip()
+    system_prompt, prompt_preset, prompt_source = resolve_prompt_reference(
+        prompt_preset=args.prompt_preset,
+        prompt_file=args.system_prompt_file,
+        prompt_text=args.system_prompt,
+        catalog_path=args.prompt_catalog,
+    )
 
     return BenchmarkProfile(
         name=profile_name,
@@ -189,6 +191,8 @@ def _default_profile_from_args(args: argparse.Namespace) -> BenchmarkProfile:
         enable_thinking=args.thinking,
         use_tools=not args.no_tools,
         system_prompt=system_prompt or None,
+        prompt_preset=prompt_preset,
+        prompt_source=prompt_source,
         max_tokens=args.max_tokens,
         temperature=args.temperature,
         env=env,
@@ -221,6 +225,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--matrix",
         default=None,
         help="JSON matrix file with 'profiles' list. If omitted, single profile args are used.",
+    )
+    parser.add_argument(
+        "--prompt-preset",
+        default=None,
+        help="Prompt preset name from prompts/catalog.json for single-profile mode",
+    )
+    parser.add_argument(
+        "--prompt-catalog",
+        default=str(DEFAULT_PROMPT_CATALOG),
+        help="Prompt catalog JSON path used with --prompt-preset",
     )
     parser.add_argument(
         "--output",

--- a/scripts/review_prompts.py
+++ b/scripts/review_prompts.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Review prompt presets and optionally benchmark them."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from talkbot.benchmark import BenchmarkProfile, load_scenarios, run_benchmark, write_outputs
+from talkbot.prompting import DEFAULT_PROMPT_CATALOG, PromptPreset, load_prompt_catalog, review_prompt_preset
+
+
+load_dotenv()
+
+
+DEFAULT_LOCAL_SERVER_MODEL = "qwen3.5-0.8b-q8_0"
+
+
+def _default_provider() -> str:
+    return os.getenv("TALKBOT_LLM_PROVIDER", "local_server")
+
+
+def _default_model(provider: str) -> str:
+    if provider == "local_server":
+        configured = (os.getenv("TALKBOT_LOCAL_SERVER_MODEL") or "").strip()
+        return configured or DEFAULT_LOCAL_SERVER_MODEL
+    configured = (os.getenv("TALKBOT_DEFAULT_MODEL") or "").strip()
+    if configured:
+        return configured
+    if provider == "openrouter":
+        return "mistralai/ministral-3b-2512"
+    return "qwen/qwen3-1.7b"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    provider = _default_provider()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", default=str(DEFAULT_PROMPT_CATALOG), help="Prompt catalog JSON path")
+    parser.add_argument("--preset", action="append", default=None, help="Prompt preset name to review")
+    parser.add_argument(
+        "--scenarios",
+        default="tests/conversations",
+        help="Scenario JSON file or directory used for prompt review",
+    )
+    parser.add_argument(
+        "--output",
+        default="benchmark_results/prompts/latest",
+        help="Benchmark output directory when --run-benchmark is used",
+    )
+    parser.add_argument("--run-benchmark", action="store_true", help="Run the prompt presets against review scenarios")
+    parser.add_argument("--provider", default=provider, choices=["local", "local_server", "openrouter"])
+    parser.add_argument("--model", default=_default_model(provider))
+    parser.add_argument("--api-key", default=os.getenv("OPENROUTER_API_KEY", ""))
+    parser.add_argument("--local-model-path", default=os.getenv("TALKBOT_LOCAL_MODEL_PATH", ""))
+    parser.add_argument("--llamacpp-bin", default=os.getenv("TALKBOT_LLAMACPP_BIN", "llama-cli"))
+    parser.add_argument(
+        "--local-server-url",
+        default=os.getenv("TALKBOT_LOCAL_SERVER_URL", "http://127.0.0.1:8000/v1"),
+    )
+    parser.add_argument("--local-server-api-key", default=os.getenv("TALKBOT_LOCAL_SERVER_API_KEY", ""))
+    parser.add_argument("--max-tokens", type=int, default=int(os.getenv("TALKBOT_MAX_TOKENS", "512") or "512"))
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--no-tools", action="store_true", help="Disable tool registration in the benchmark")
+    return parser.parse_args(argv)
+
+
+def _select_presets(all_presets: list[PromptPreset], names: list[str] | None) -> list[PromptPreset]:
+    if not names:
+        return all_presets
+    wanted = {name.strip().lower() for name in names if name.strip()}
+    selected = [preset for preset in all_presets if preset.name.lower() in wanted]
+    missing = sorted(wanted - {preset.name.lower() for preset in selected})
+    if missing:
+        raise KeyError(f"Unknown prompt preset(s): {', '.join(missing)}")
+    return selected
+
+
+def _filter_review_scenarios(all_scenarios: list[dict], presets: list[PromptPreset]) -> list[dict]:
+    scenario_ids = {scenario["id"] for scenario in all_scenarios}
+    wanted = {scenario_id for preset in presets for scenario_id in preset.scenarios}
+    if not wanted:
+        return all_scenarios
+    missing = sorted(wanted - scenario_ids)
+    if missing:
+        raise ValueError(f"Unknown scenario id(s) in prompt catalog: {', '.join(missing)}")
+    return [scenario for scenario in all_scenarios if scenario["id"] in wanted]
+
+
+def _print_review(presets: list[PromptPreset], scenario_ids: set[str]) -> int:
+    error_count = 0
+    warning_count = 0
+    for preset in presets:
+        findings = review_prompt_preset(preset, available_scenarios=scenario_ids)
+        errors = [finding for finding in findings if finding.severity == "error"]
+        warnings = [finding for finding in findings if finding.severity == "warning"]
+        error_count += len(errors)
+        warning_count += len(warnings)
+
+        rel_path = preset.path
+        try:
+            rel_path = preset.path.relative_to(Path.cwd())
+        except ValueError:
+            pass
+
+        print(f"[{preset.name}] {rel_path}")
+        print(f"Summary: {preset.summary or '(missing summary)'}")
+        print(f"Goals: {', '.join(preset.goals) if preset.goals else '(none)'}")
+        print(f"Scenarios: {', '.join(preset.scenarios) if preset.scenarios else '(none)'}")
+        if preset.review_notes:
+            print(f"Notes: {preset.review_notes}")
+        if not findings:
+            print("Review: OK")
+        else:
+            for finding in findings:
+                print(f"{finding.severity.upper()}: {finding.code} - {finding.message}")
+        print()
+
+    print(f"Summary: {len(presets)} preset(s), {error_count} error(s), {warning_count} warning(s)")
+    return 1 if error_count else 0
+
+
+def _build_profiles(args: argparse.Namespace, presets: list[PromptPreset]) -> list[BenchmarkProfile]:
+    profiles: list[BenchmarkProfile] = []
+    for preset in presets:
+        profiles.append(
+            BenchmarkProfile(
+                name=f"prompt-{preset.name}",
+                provider=args.provider,
+                model=args.model,
+                api_key=args.api_key or None,
+                local_model_path=args.local_model_path or None,
+                llamacpp_bin=args.llamacpp_bin or None,
+                local_server_url=args.local_server_url or None,
+                local_server_api_key=args.local_server_api_key or None,
+                use_tools=not args.no_tools,
+                system_prompt=preset.load_text() or None,
+                prompt_preset=preset.name,
+                prompt_source=f"preset:{preset.name}",
+                max_tokens=args.max_tokens,
+                temperature=args.temperature,
+            )
+        )
+    return profiles
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    presets = _select_presets(load_prompt_catalog(args.catalog), args.preset)
+    scenarios = load_scenarios(args.scenarios)
+    scenario_ids = {scenario["id"] for scenario in scenarios}
+
+    review_exit = _print_review(presets, scenario_ids)
+    if review_exit or not args.run_benchmark:
+        return review_exit
+
+    review_scenarios = _filter_review_scenarios(scenarios, presets)
+    report = run_benchmark(
+        profiles=_build_profiles(args, presets),
+        scenarios=review_scenarios,
+        output_dir=args.output,
+    )
+    paths = write_outputs(report, args.output)
+    print(f"Benchmark results: {paths['results']}")
+    print(f"Benchmark leaderboard: {paths['leaderboard']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/talkbot/benchmark.py
+++ b/src/talkbot/benchmark.py
@@ -23,6 +23,7 @@ from typing import Any, Callable
 
 from talkbot.judge import JudgeResult, LLMJudge
 from talkbot.llm import create_llm_client, supports_tools
+from talkbot.prompting import resolve_prompt_reference
 from talkbot.text_utils import normalize_for_tts, tts_friction_score
 from talkbot.tools import TOOL_DEFINITIONS, TOOLS, get_tool_definitions_for_variant, reset_runtime_state
 
@@ -71,6 +72,8 @@ class BenchmarkProfile:
     enable_thinking: bool = False
     use_tools: bool = True
     system_prompt: str | None = None
+    prompt_preset: str | None = None
+    prompt_source: str | None = None
     max_tokens: int = 512
     temperature: float = 0.0
     env: dict[str, str] = field(default_factory=dict)
@@ -562,6 +565,21 @@ def _expand_profile_entry(entry: dict[str, Any]) -> list[BenchmarkProfile]:
     base = {k: v for k, v in entry.items() if not k.startswith("_")}
     context_windows = base.pop("context_windows", None)
     n_ctx = base.pop("n_ctx", None)
+    prompt_catalog = base.pop("prompt_catalog", None)
+    prompt_preset = base.pop("prompt_preset", None)
+    prompt_file = base.pop("prompt_file", None)
+    system_prompt_file = base.pop("system_prompt_file", None)
+
+    resolved_prompt, resolved_preset, resolved_source = resolve_prompt_reference(
+        prompt_preset=prompt_preset,
+        prompt_file=prompt_file or system_prompt_file,
+        prompt_text=base.get("system_prompt"),
+        catalog_path=prompt_catalog,
+    )
+    if resolved_prompt is not None:
+        base["system_prompt"] = resolved_prompt
+    base["prompt_preset"] = resolved_preset
+    base["prompt_source"] = resolved_source
 
     env = dict(base.get("env") or {})
     base["env"] = env
@@ -1924,6 +1942,20 @@ def _routing_mode(profile: dict[str, Any]) -> str:
     return "llm"
 
 
+def _prompt_label(profile: dict[str, Any]) -> str:
+    preset = str(profile.get("prompt_preset") or "").strip()
+    if preset:
+        return preset
+    source = str(profile.get("prompt_source") or "").strip()
+    if source.startswith("preset:"):
+        return source.split(":", 1)[1]
+    if source.startswith("file:"):
+        return source.split(":", 1)[1]
+    if source == "inline":
+        return "inline"
+    return "default"
+
+
 def _tts_directive_mode(profile: dict[str, Any]) -> str:
     """Return 'tts' if profile has tts_directive enabled, else 'baseline'."""
     val = profile.get("tts_directive")
@@ -2009,6 +2041,77 @@ def _ab_compare_key(profile: dict[str, Any]) -> tuple[str, str, str, int]:
     variant = Path(local_path).name if local_path else ""
     ctx = _extract_context_window(profile) or 0
     return (provider, model, variant, ctx)
+
+
+def _prompt_compare_key(profile: dict[str, Any]) -> tuple[str, str, str, int, str, str]:
+    provider = str(profile.get("provider") or "")
+    model = str(profile.get("model") or "")
+    local_path = str(profile.get("local_model_path") or "")
+    variant = Path(local_path).name if local_path else ""
+    ctx = _extract_context_window(profile) or 0
+    routing = _routing_mode(profile)
+    temp = f"{float(profile.get('temperature', 0.0) or 0.0):.3f}"
+    return (provider, model, variant, ctx, routing, temp)
+
+
+def _prompt_compare_label(key: tuple[str, str, str, int, str, str]) -> str:
+    provider, model, variant, ctx, routing, temp = key
+    base = f"{provider}/{model}"
+    if variant:
+        base = f"{base} ({variant})"
+    return f"{base} @ctx{ctx} {routing.upper()} temp={temp}"
+
+
+def _prompt_comparison_rows(
+    runs: list[dict[str, Any]],
+    rubric: dict[str, Any],
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str, str, int, str, str], list[dict[str, Any]]] = {}
+    for run in runs:
+        profile = run.get("profile") or {}
+        aggregate = run.get("aggregate") or {}
+        grouped.setdefault(_prompt_compare_key(profile), []).append(
+            {
+                "prompt": _prompt_label(profile),
+                "score": _rubric_score(aggregate, rubric),
+                "success": _coerce_float(aggregate.get("task_success_rate"), 0.0),
+                "tool": _coerce_float(aggregate.get("tool_selection_accuracy"), 0.0),
+                "latency_ms": _coerce_float(aggregate.get("avg_turn_latency_ms"), 0.0),
+                "run": run,
+            }
+        )
+
+    rows: list[dict[str, Any]] = []
+    for key, samples in grouped.items():
+        prompt_names = {sample["prompt"] for sample in samples}
+        if len(prompt_names) < 2:
+            continue
+        ranked = sorted(
+            samples,
+            key=lambda sample: (sample["score"], sample["success"], sample["tool"]),
+            reverse=True,
+        )
+        best = ranked[0]
+        worst = ranked[-1]
+        rows.append(
+            {
+                "label": _prompt_compare_label(key),
+                "best_prompt": best["prompt"],
+                "best_score": best["score"],
+                "best_success": best["success"],
+                "best_tool": best["tool"],
+                "worst_prompt": worst["prompt"],
+                "worst_score": worst["score"],
+                "worst_success": worst["success"],
+                "worst_tool": worst["tool"],
+                "score_delta": best["score"] - worst["score"],
+                "success_delta": best["success"] - worst["success"],
+                "tool_delta": best["tool"] - worst["tool"],
+                "prompt_count": len(prompt_names),
+            }
+        )
+    rows.sort(key=lambda row: (row["score_delta"], row["success_delta"]), reverse=True)
+    return rows
 
 
 def _ab_compare_label(key: tuple[str, str, str, int]) -> str:
@@ -2219,6 +2322,7 @@ def build_leaderboard_markdown(report: dict[str, Any]) -> str:
     context_rows = _context_sweep_summary(runs, rubric, context_analysis)
     ab_rows = _ab_comparison_rows(runs, rubric)
     tts_ab_rows = _tts_directive_ab_rows(runs)
+    prompt_rows = _prompt_comparison_rows(runs, rubric)
 
     quality_rank = sorted(
         runs,
@@ -2304,7 +2408,7 @@ def build_leaderboard_markdown(report: dict[str, Any]) -> str:
         routing = _routing_mode(profile).upper()
         base = (
             f"| {profile.get('name', '')} | {profile.get('provider', '')} | "
-            f"{profile.get('model', '')} | {routing} | "
+            f"{profile.get('model', '')} | {_prompt_label(profile)} | {routing} | "
             f"{profile.get('temperature', 0.0):.1f} | "
             f"{_coerce_float(agg.get('task_success_rate'), 0.0):.2%} | "
             f"{_coerce_float(agg.get('tool_selection_accuracy'), 0.0):.2%} | "
@@ -2398,8 +2502,8 @@ def build_leaderboard_markdown(report: dict[str, Any]) -> str:
             "",
             "## Quality Rank",
             "",
-            "| Run | Provider | Model | Routing | Temp | Success | Tool Sel | Arg Acc | Recovery | Avg ms | Mem MB | Tool Err | Pfill/s | Gen/s | Tokens |",
-            "|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+            "| Run | Provider | Model | Prompt | Routing | Temp | Success | Tool Sel | Arg Acc | Recovery | Avg ms | Mem MB | Tool Err | Pfill/s | Gen/s | Tokens |",
+            "|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
         ]
     )
     lines.extend(row(run) for run in quality_rank)
@@ -2409,8 +2513,8 @@ def build_leaderboard_markdown(report: dict[str, Any]) -> str:
             "",
             "## Low-Memory Rank",
             "",
-            "| Run | Provider | Model | Routing | Temp | Success | Tool Sel | Arg Acc | Recovery | Avg ms | Mem MB | Tool Err | Pfill/s | Gen/s | Tokens |",
-            "|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+            "| Run | Provider | Model | Prompt | Routing | Temp | Success | Tool Sel | Arg Acc | Recovery | Avg ms | Mem MB | Tool Err | Pfill/s | Gen/s | Tokens |",
+            "|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
         ]
     )
     lines.extend(row(run) for run in low_mem_rank)
@@ -2420,8 +2524,8 @@ def build_leaderboard_markdown(report: dict[str, Any]) -> str:
             "",
             "## Balanced Rank",
             "",
-            "| Run | Provider | Model | Routing | Temp | Success | Tool Sel | Arg Acc | Recovery | Avg ms | Mem MB | Tool Err | Pfill/s | Gen/s | Tokens | Score |",
-            "|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+            "| Run | Provider | Model | Prompt | Routing | Temp | Success | Tool Sel | Arg Acc | Recovery | Avg ms | Mem MB | Tool Err | Pfill/s | Gen/s | Tokens | Score |",
+            "|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
         ]
     )
     lines.extend(row(run, include_score=True) for run in balanced_rank)
@@ -2439,8 +2543,8 @@ def build_leaderboard_markdown(report: dict[str, Any]) -> str:
     if remote_rank:
         lines.extend(
             [
-                "| Run | Provider | Model | Routing | Temp | Success | Tool Sel | Arg Acc | Recovery | Avg ms | Mem MB | Tool Err | Pfill/s | Gen/s | Tokens | Score (Remote) |",
-                "|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+                "| Run | Provider | Model | Prompt | Routing | Temp | Success | Tool Sel | Arg Acc | Recovery | Avg ms | Mem MB | Tool Err | Pfill/s | Gen/s | Tokens | Score (Remote) |",
+                "|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
             ]
         )
         lines.extend(
@@ -2459,8 +2563,8 @@ def build_leaderboard_markdown(report: dict[str, Any]) -> str:
             "",
             "## Efficiency Rank",
             "",
-            "| Run | Provider | Model | Routing | Temp | Success | Tool Sel | Arg Acc | Recovery | Avg ms | Mem MB | Tool Err | Pfill/s | Gen/s | Tokens |",
-            "|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+            "| Run | Provider | Model | Prompt | Routing | Temp | Success | Tool Sel | Arg Acc | Recovery | Avg ms | Mem MB | Tool Err | Pfill/s | Gen/s | Tokens |",
+            "|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
         ]
     )
     lines.extend(row(run) for run in efficiency_rank)
@@ -2510,11 +2614,42 @@ def build_leaderboard_markdown(report: dict[str, Any]) -> str:
             "",
             "## Pareto Frontier (Quality/Latency/Memory)",
             "",
-            "| Run | Provider | Model | Routing | Temp | Success | Tool Sel | Arg Acc | Recovery | Avg ms | Mem MB | Tool Err | Pfill/s | Gen/s | Tokens | Score |",
-            "|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+            "| Run | Provider | Model | Prompt | Routing | Temp | Success | Tool Sel | Arg Acc | Recovery | Avg ms | Mem MB | Tool Err | Pfill/s | Gen/s | Tokens | Score |",
+            "|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
         ]
     )
     lines.extend(row(run, include_score=True) for run in pareto)
+
+    lines.extend(
+        [
+            "",
+            "## Prompt Impact",
+            "",
+            "- Compares runs that share provider, model, context, routing mode, and temperature.",
+            "- Use this to isolate prompt effects from model/runtime effects.",
+            "",
+        ]
+    )
+    if prompt_rows:
+        lines.extend(
+            [
+                "| Model Slice | Prompts | Best Prompt | Best Score | Worst Prompt | Worst Score | Score Δ | Success Δ | Tool Sel Δ |",
+                "|---|---:|---|---:|---|---:|---:|---:|---:|",
+            ]
+        )
+        lines.extend(
+            (
+                f"| {row['label']} | {row['prompt_count']} | "
+                f"{row['best_prompt']} | {row['best_score']:.3f} | "
+                f"{row['worst_prompt']} | {row['worst_score']:.3f} | "
+                f"{row['score_delta']:+.3f} | {row['success_delta']:+.2%} | {row['tool_delta']:+.2%} |"
+            )
+            for row in prompt_rows
+        )
+    else:
+        lines.append(
+            "No matched prompt comparison groups found. Run the same model/runtime slice with two or more prompt presets."
+        )
 
     lines.extend(
         [
@@ -2640,6 +2775,15 @@ def build_leaderboard_markdown(report: dict[str, Any]) -> str:
             [
                 f"- Routing gap summary: intent minus llm avg success delta = {avg_success_gap:+.2%}",
                 f"- Routing gap summary: intent minus llm avg score delta = {avg_score_gap:+.3f}",
+            ]
+        )
+    if prompt_rows:
+        avg_prompt_score_gap = statistics.fmean(row["score_delta"] for row in prompt_rows)
+        avg_prompt_success_gap = statistics.fmean(row["success_delta"] for row in prompt_rows)
+        lines.extend(
+            [
+                f"- Prompt gap summary: best minus worst avg score delta = {avg_prompt_score_gap:+.3f}",
+                f"- Prompt gap summary: best minus worst avg success delta = {avg_prompt_success_gap:+.2%}",
             ]
         )
 

--- a/src/talkbot/cli.py
+++ b/src/talkbot/cli.py
@@ -14,6 +14,7 @@ if env_path.exists():
     load_dotenv(env_path)
 
 from talkbot.llm import LLMProviderError, create_llm_client, supports_tools
+from talkbot.prompting import load_agent_prompt
 from talkbot.thinking import apply_thinking_system_prompt, env_thinking_default
 from talkbot.text_utils import strip_thinking
 from talkbot.tools import register_all_tools, set_alert_callback
@@ -35,7 +36,7 @@ def _default_tts_backend() -> str:
 
 def _default_agent_prompt() -> str | None:
     """Return the agent system prompt from env, or None if unset."""
-    return os.getenv("TALKBOT_AGENT_PROMPT") or None
+    return load_agent_prompt()
 
 
 def _default_provider() -> str:
@@ -165,7 +166,7 @@ def cli(
     "--system",
     "-s",
     default=lambda: _default_agent_prompt(),
-    help="System prompt (defaults to env:TALKBOT_AGENT_PROMPT)",
+    help="System prompt (defaults to env:TALKBOT_AGENT_PROMPT_FILE or TALKBOT_AGENT_PROMPT)",
 )
 @click.option("--tools/--no-tools", default=False, help="Enable built-in tools")
 @click.pass_context
@@ -224,7 +225,7 @@ def chat(
     "--system",
     "-s",
     default=lambda: _default_agent_prompt(),
-    help="System prompt (defaults to env:TALKBOT_AGENT_PROMPT)",
+    help="System prompt (defaults to env:TALKBOT_AGENT_PROMPT_FILE or TALKBOT_AGENT_PROMPT)",
 )
 @click.pass_context
 def say(
@@ -398,7 +399,7 @@ def doctor_tts(backends: tuple[str, ...], synthesize: bool) -> None:
     "--system",
     "-s",
     default=lambda: _default_agent_prompt(),
-    help="System prompt (defaults to env:TALKBOT_AGENT_PROMPT)",
+    help="System prompt (defaults to env:TALKBOT_AGENT_PROMPT_FILE or TALKBOT_AGENT_PROMPT)",
 )
 @click.pass_context
 def tool(
@@ -453,7 +454,7 @@ def tool(
     "--system",
     "-s",
     default=lambda: _default_agent_prompt(),
-    help="System prompt (defaults to env:TALKBOT_AGENT_PROMPT)",
+    help="System prompt (defaults to env:TALKBOT_AGENT_PROMPT_FILE or TALKBOT_AGENT_PROMPT)",
 )
 @click.option("--stt-model", default="small.en", help="faster-whisper model")
 @click.option("--language", default="en", help="STT language")

--- a/src/talkbot/prompting.py
+++ b/src/talkbot/prompting.py
@@ -1,0 +1,319 @@
+"""Helpers for loading, cataloging, and reviewing prompt presets."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from talkbot.tools import TOOLS
+
+
+DEFAULT_PROMPT_CATALOG = Path("prompts/catalog.json")
+
+
+@dataclass(frozen=True)
+class PromptPreset:
+    """Named prompt preset tracked in the prompt catalog."""
+
+    name: str
+    path: Path
+    summary: str = ""
+    goals: tuple[str, ...] = ()
+    scenarios: tuple[str, ...] = ()
+    review_notes: str = ""
+
+    def load_text(self) -> str:
+        try:
+            return self.path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return ""
+
+
+@dataclass(frozen=True)
+class PromptReviewFinding:
+    """Single prompt review issue or note."""
+
+    severity: str
+    code: str
+    message: str
+
+
+def _resolve_prompt_file(path_str: str) -> Path:
+    path = Path(path_str).expanduser()
+    if path.is_absolute():
+        return path
+    return Path.cwd() / path
+
+
+def _resolve_catalog_path(path: str | Path | None = None) -> Path:
+    candidate = Path(path) if path is not None else DEFAULT_PROMPT_CATALOG
+    candidate = candidate.expanduser()
+    if candidate.is_absolute():
+        return candidate
+    return Path.cwd() / candidate
+
+
+def describe_prompt_path(path: Path) -> str:
+    """Return a stable display label for a prompt file path."""
+    try:
+        return str(path.relative_to(Path.cwd()))
+    except ValueError:
+        return str(path)
+
+
+def load_prompt_catalog(path: str | Path | None = None) -> list[PromptPreset]:
+    """Load prompt presets from a JSON catalog."""
+    catalog_path = _resolve_catalog_path(path)
+    payload = json.loads(catalog_path.read_text(encoding="utf-8"))
+    raw_prompts = payload.get("prompts", payload) if isinstance(payload, dict) else payload
+    if not isinstance(raw_prompts, list):
+        raise ValueError(f"Prompt catalog at '{catalog_path}' must contain a prompt list.")
+
+    presets: list[PromptPreset] = []
+    for index, entry in enumerate(raw_prompts):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Prompt catalog entry #{index} must be an object.")
+        name = str(entry.get("name") or "").strip()
+        file_value = str(entry.get("file") or "").strip()
+        if not name or not file_value:
+            raise ValueError(f"Prompt catalog entry #{index} must define 'name' and 'file'.")
+
+        file_path = Path(file_value).expanduser()
+        if not file_path.is_absolute():
+            file_path = (catalog_path.parent / file_path).resolve()
+
+        goals = tuple(str(goal).strip() for goal in entry.get("goals") or [] if str(goal).strip())
+        scenarios = tuple(
+            str(scenario).strip() for scenario in entry.get("scenarios") or [] if str(scenario).strip()
+        )
+        presets.append(
+            PromptPreset(
+                name=name,
+                path=file_path,
+                summary=str(entry.get("summary") or "").strip(),
+                goals=goals,
+                scenarios=scenarios,
+                review_notes=str(entry.get("review_notes") or "").strip(),
+            )
+        )
+
+    return sorted(presets, key=lambda preset: preset.name)
+
+
+def get_prompt_preset(name: str, path: str | Path | None = None) -> PromptPreset:
+    """Return a prompt preset by catalog name."""
+    target = str(name or "").strip().lower()
+    for preset in load_prompt_catalog(path):
+        if preset.name.lower() == target:
+            return preset
+    raise KeyError(f"Unknown prompt preset '{name}'.")
+
+
+def resolve_prompt_reference(
+    *,
+    prompt_preset: str | None = None,
+    prompt_file: str | Path | None = None,
+    prompt_text: str | None = None,
+    catalog_path: str | Path | None = None,
+) -> tuple[str | None, str | None, str | None]:
+    """Resolve prompt text plus stable preset/source metadata.
+
+    Returns ``(text, preset_name, source_label)``.
+    """
+    preset_name = str(prompt_preset or "").strip()
+    file_value = str(prompt_file or "").strip()
+    text_value = str(prompt_text or "").strip()
+
+    specified = sum(bool(value) for value in (preset_name, file_value, text_value))
+    if specified > 1:
+        raise ValueError("Specify only one of prompt_preset, prompt_file, or prompt_text.")
+
+    if preset_name:
+        preset = get_prompt_preset(preset_name, catalog_path)
+        return preset.load_text() or None, preset.name, f"preset:{preset.name}"
+
+    if file_value:
+        resolved = _resolve_prompt_file(file_value)
+        try:
+            text = resolved.read_text(encoding="utf-8").strip()
+        except OSError:
+            text = ""
+        return text or None, None, f"file:{describe_prompt_path(resolved)}"
+
+    if text_value:
+        return text_value, None, "inline"
+
+    return None, None, None
+
+
+def _extract_tool_references(text: str) -> set[str]:
+    refs = set(re.findall(r"`([a-z_][a-z0-9_]*)`", text))
+    refs.update(re.findall(r"\b([a-z_][a-z0-9_]*)\(", text))
+    return refs
+
+
+def review_prompt_preset(
+    preset: PromptPreset,
+    *,
+    available_scenarios: set[str] | None = None,
+) -> list[PromptReviewFinding]:
+    """Return heuristic prompt review findings for a preset."""
+    findings: list[PromptReviewFinding] = []
+    text = preset.load_text()
+    lowered = text.lower()
+
+    if not preset.path.exists():
+        findings.append(
+            PromptReviewFinding(
+                severity="error",
+                code="missing_file",
+                message=f"Prompt file does not exist: {preset.path}",
+            )
+        )
+        return findings
+
+    if not text:
+        findings.append(
+            PromptReviewFinding(
+                severity="error",
+                code="empty_prompt",
+                message="Prompt file is empty.",
+            )
+        )
+        return findings
+
+    if not preset.summary:
+        findings.append(
+            PromptReviewFinding(
+                severity="warning",
+                code="missing_summary",
+                message="Prompt catalog entry is missing a summary.",
+            )
+        )
+
+    if not preset.goals:
+        findings.append(
+            PromptReviewFinding(
+                severity="warning",
+                code="missing_goals",
+                message="Prompt catalog entry has no declared goals.",
+            )
+        )
+
+    if not preset.scenarios:
+        findings.append(
+            PromptReviewFinding(
+                severity="warning",
+                code="missing_scenarios",
+                message="Prompt catalog entry has no review scenarios.",
+            )
+        )
+
+    if len(text) < 120:
+        findings.append(
+            PromptReviewFinding(
+                severity="warning",
+                code="prompt_too_short",
+                message="Prompt is very short; review whether it carries enough behavioral guidance.",
+            )
+        )
+
+    if len(text) > 4000:
+        findings.append(
+            PromptReviewFinding(
+                severity="warning",
+                code="prompt_too_long",
+                message="Prompt is long enough to risk avoidable context cost and instruction conflicts.",
+            )
+        )
+
+    if "tool_first" in preset.goals and "tool" not in lowered:
+        findings.append(
+            PromptReviewFinding(
+                severity="error",
+                code="missing_tool_guidance",
+                message="Prompt goal says tool-first, but the prompt text never mentions tools.",
+            )
+        )
+
+    if "voice" in preset.goals and not any(
+        token in lowered for token in ("voice", "spoken", "speak", "speaking", "aloud")
+    ):
+        findings.append(
+            PromptReviewFinding(
+                severity="warning",
+                code="missing_voice_guidance",
+                message="Voice-oriented preset does not clearly mention spoken or voice output.",
+            )
+        )
+
+    if "exact_args" in preset.goals and not any(
+        phrase in lowered
+        for phrase in ("exact parameter", "parameter name", "exact tool parameter", "exact argument")
+    ):
+        findings.append(
+            PromptReviewFinding(
+                severity="warning",
+                code="missing_exact_args_guidance",
+                message="Preset expects exact tool arguments, but the prompt does not state that clearly.",
+            )
+        )
+
+    if available_scenarios is not None:
+        missing_scenarios = sorted(set(preset.scenarios) - set(available_scenarios))
+        for scenario_id in missing_scenarios:
+            findings.append(
+                PromptReviewFinding(
+                    severity="error",
+                    code="unknown_scenario",
+                    message=f"Catalog references unknown review scenario '{scenario_id}'.",
+                )
+            )
+
+    known_tools = set(TOOLS)
+    unknown_tool_refs = sorted(
+        ref for ref in _extract_tool_references(text) if ref not in known_tools
+    )
+    for tool_name in unknown_tool_refs:
+        findings.append(
+            PromptReviewFinding(
+                severity="error",
+                code="unknown_tool_reference",
+                message=f"Prompt references unknown tool '{tool_name}'.",
+            )
+        )
+
+    return findings
+
+
+def get_agent_prompt_details() -> tuple[str | None, str]:
+    """Return the default agent prompt and a human-readable source label.
+
+    Precedence:
+    1. ``TALKBOT_AGENT_PROMPT_FILE``
+    2. ``TALKBOT_AGENT_PROMPT``
+    """
+    prompt_file = (os.getenv("TALKBOT_AGENT_PROMPT_FILE") or "").strip()
+    if prompt_file:
+        resolved = _resolve_prompt_file(prompt_file)
+        try:
+            text = resolved.read_text(encoding="utf-8").strip()
+        except OSError:
+            text = ""
+        if text:
+            display = describe_prompt_path(resolved)
+            return text, f"file: {display}"
+
+    prompt = (os.getenv("TALKBOT_AGENT_PROMPT") or "").strip()
+    if prompt:
+        return prompt, "env: TALKBOT_AGENT_PROMPT"
+    return None, "default: empty"
+
+
+def load_agent_prompt() -> str | None:
+    """Load the default agent prompt from env or an external file."""
+    prompt, _source = get_agent_prompt_details()
+    return prompt

--- a/src/talkbot/ui/tabs/prompt_tab.py
+++ b/src/talkbot/ui/tabs/prompt_tab.py
@@ -1,12 +1,13 @@
 """Prompt tab UI components."""
 import tkinter as tk
-import os
+
+from talkbot.prompting import get_agent_prompt_details
 from talkbot.ui.components import ModernStyle
 
 def create_prompt_tab(parent: tk.Widget) -> tuple[tk.Text, tk.Widget]:
     """Create the Prompt tab and return the text widget."""
     tab_prompt = tk.Frame(parent, bg=ModernStyle.BG_SECONDARY)
-    
+
     prompt_help = tk.Label(
         tab_prompt,
         text="System prompt used for text and voice conversations.",
@@ -16,6 +17,17 @@ def create_prompt_tab(parent: tk.Widget) -> tuple[tk.Text, tk.Widget]:
         anchor=tk.W,
     )
     prompt_help.pack(fill=tk.X, padx=8, pady=(8, 4))
+
+    prompt_value, prompt_source = get_agent_prompt_details()
+    prompt_source_label = tk.Label(
+        tab_prompt,
+        text=f"Active source: {prompt_source}",
+        bg=ModernStyle.BG_SECONDARY,
+        fg=ModernStyle.TEXT_SECONDARY,
+        font=(ModernStyle.FONT_FAMILY, ModernStyle.FONT_SIZE_SMALL),
+        anchor=tk.W,
+    )
+    prompt_source_label.pack(fill=tk.X, padx=8, pady=(0, 6))
 
     prompt_text = tk.Text(
         tab_prompt,
@@ -31,9 +43,8 @@ def create_prompt_tab(parent: tk.Widget) -> tuple[tk.Text, tk.Widget]:
     )
     prompt_text.pack(fill=tk.BOTH, expand=True, padx=8, pady=(0, 8))
 
-    # Pre-populate from env var if set
-    env_prompt = os.getenv("TALKBOT_AGENT_PROMPT", "").strip()
-    if env_prompt:
-        prompt_text.insert("1.0", env_prompt)
-        
+    # Pre-populate from prompt file or env if set.
+    if prompt_value:
+        prompt_text.insert("1.0", prompt_value)
+
     return prompt_text, tab_prompt

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -142,6 +142,8 @@ def test_write_outputs_and_leaderboard(tmp_path):
                     "name": "demo-ctx2048",
                     "provider": "local",
                     "model": "fake/model",
+                    "prompt_preset": "tool_reliability",
+                    "prompt_source": "preset:tool_reliability",
                     "env": {"TALKBOT_LOCAL_N_CTX": "2048"},
                 },
                 "status": "ok",
@@ -162,6 +164,8 @@ def test_write_outputs_and_leaderboard(tmp_path):
                     "name": "demo-ctx4096",
                     "provider": "local",
                     "model": "fake/model",
+                    "prompt_preset": "agent",
+                    "prompt_source": "preset:agent",
                     "env": {"TALKBOT_LOCAL_N_CTX": "4096"},
                 },
                 "status": "ok",
@@ -185,7 +189,8 @@ def test_write_outputs_and_leaderboard(tmp_path):
     assert "Runner: `linux-main`" in md
     assert "Runner notes: cpu-only" in md
     assert "Quality Rank" in md
-    assert "| Run | Provider | Model | Routing |" in md
+    assert "| Run | Provider | Model | Prompt | Routing |" in md
+    assert "## Prompt Impact" in md
     assert "Low-Memory Rank" in md
     assert "Balanced Rank" in md
     assert "Pareto Frontier" in md
@@ -238,6 +243,52 @@ def test_load_matrix_config_expands_context_windows(tmp_path):
     assert matrix["rubric"]["weights"]["task_success_rate"] == 0.7
     assert matrix["context_analysis"]["near_peak_ratio"] == 0.96
     assert matrix["context_analysis"]["dropoff_ratio"] == 0.88
+
+
+def test_load_matrix_config_resolves_prompt_preset(tmp_path):
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    (prompt_dir / "sample.md").write_text("Use tools first.", encoding="utf-8")
+    catalog_path = prompt_dir / "catalog.json"
+    catalog_path.write_text(
+        json.dumps(
+            {
+                "prompts": [
+                    {
+                        "name": "sample",
+                        "file": "sample.md",
+                        "summary": "Sample",
+                        "goals": ["tool_first"],
+                        "scenarios": ["utility_time_date"],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    matrix_path = tmp_path / "matrix.json"
+    matrix_path.write_text(
+        json.dumps(
+            {
+                "profiles": [
+                    {
+                        "name": "demo",
+                        "provider": "local",
+                        "model": "fake/model",
+                        "prompt_catalog": str(catalog_path),
+                        "prompt_preset": "sample",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    matrix = load_matrix_config(matrix_path)
+
+    assert matrix["profiles"][0].prompt_preset == "sample"
+    assert matrix["profiles"][0].prompt_source == "preset:sample"
+    assert matrix["profiles"][0].system_prompt == "Use tools first."
 
 
 def test_leaderboard_includes_ab_routing_section():
@@ -998,3 +1049,70 @@ def test_tts_directive_ab_leaderboard_section_rendered(tmp_path):
     assert "## TTS Directive A/B" in md
     assert "Friction" in md
     assert "-3.00" in md  # friction_delta
+
+
+def test_prompt_impact_leaderboard_section_rendered():
+    runs = [
+        {
+            "profile": {
+                "name": "slice-a",
+                "provider": "local_server",
+                "model": "qwen3.5",
+                "prompt_preset": "agent",
+                "temperature": 0.0,
+                "env": {"TALKBOT_LOCAL_N_CTX": "4096", "TALKBOT_LOCAL_DIRECT_TOOL_ROUTING": "1"},
+            },
+            "status": "ok",
+            "aggregate": {
+                "task_success_rate": 0.80,
+                "tool_selection_accuracy": 0.80,
+                "argument_accuracy": 0.80,
+                "avg_turn_latency_ms": 20.0,
+                "memory_peak_mb": 10.0,
+                "tool_call_error_rate": 0.0,
+                "model_execution_error_rate": 0.0,
+                "tokens_per_second": 1.0,
+                "avg_prefill_tok_s": 1.0,
+                "avg_gen_tok_s": 1.0,
+                "total_tokens": 10,
+                "tag_success": {},
+            },
+        },
+        {
+            "profile": {
+                "name": "slice-b",
+                "provider": "local_server",
+                "model": "qwen3.5",
+                "prompt_preset": "tool_reliability",
+                "temperature": 0.0,
+                "env": {"TALKBOT_LOCAL_N_CTX": "4096", "TALKBOT_LOCAL_DIRECT_TOOL_ROUTING": "1"},
+            },
+            "status": "ok",
+            "aggregate": {
+                "task_success_rate": 0.95,
+                "tool_selection_accuracy": 0.95,
+                "argument_accuracy": 0.95,
+                "avg_turn_latency_ms": 18.0,
+                "memory_peak_mb": 10.0,
+                "tool_call_error_rate": 0.0,
+                "model_execution_error_rate": 0.0,
+                "tokens_per_second": 1.0,
+                "avg_prefill_tok_s": 1.0,
+                "avg_gen_tok_s": 1.0,
+                "total_tokens": 10,
+                "tag_success": {},
+            },
+        },
+    ]
+    report = {
+        "finished_at": "2026-01-01T00:00:00Z",
+        "run_count": 2,
+        "scenario_count": 3,
+        "runs": runs,
+        "meta": {},
+        "runner": {},
+    }
+    md = build_leaderboard_markdown(report)
+    assert "## Prompt Impact" in md
+    assert "tool_reliability" in md
+    assert "agent" in md

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 
 from talkbot import cli as cli_module
+from talkbot.prompting import get_agent_prompt_details
 
 
 class FakeClient:
@@ -202,6 +203,25 @@ def test_chat_command_defaults_local_server_model_when_env_unset(monkeypatch):
     assert result.exit_code == 0
     assert captured["provider"] == "local_server"
     assert captured["model"] == cli_module.DEFAULT_LOCAL_SERVER_MODEL
+
+
+def test_default_agent_prompt_reads_prompt_file(tmp_path, monkeypatch):
+    prompt_file = tmp_path / "agent.md"
+    prompt_file.write_text("Use tools first.", encoding="utf-8")
+
+    monkeypatch.delenv("TALKBOT_AGENT_PROMPT", raising=False)
+    monkeypatch.setenv("TALKBOT_AGENT_PROMPT_FILE", str(prompt_file))
+
+    assert cli_module._default_agent_prompt() == "Use tools first."
+    assert get_agent_prompt_details() == ("Use tools first.", f"file: {prompt_file}")
+
+
+def test_default_agent_prompt_falls_back_to_env_text(monkeypatch):
+    monkeypatch.delenv("TALKBOT_AGENT_PROMPT_FILE", raising=False)
+    monkeypatch.setenv("TALKBOT_AGENT_PROMPT", "Inline prompt")
+
+    assert cli_module._default_agent_prompt() == "Inline prompt"
+    assert get_agent_prompt_details() == ("Inline prompt", "env: TALKBOT_AGENT_PROMPT")
 
 
 def test_voices_command_passes_backend(monkeypatch):

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+from talkbot.prompting import (
+    PromptPreset,
+    get_prompt_preset,
+    load_prompt_catalog,
+    resolve_prompt_reference,
+    review_prompt_preset,
+)
+
+
+def test_load_prompt_catalog_reads_repo_presets():
+    presets = load_prompt_catalog()
+
+    names = [preset.name for preset in presets]
+    assert names == ["agent", "tool_benchmark", "tool_reliability"]
+    assert all(preset.path.exists() for preset in presets)
+
+
+def test_get_prompt_preset_returns_named_entry():
+    preset = get_prompt_preset("tool_reliability")
+
+    assert preset.name == "tool_reliability"
+    assert preset.path == Path.cwd() / "prompts" / "tool_reliability.md"
+    assert "tool_first" in preset.goals
+
+
+def test_review_prompt_preset_flags_unknown_tool_reference(tmp_path):
+    prompt_file = tmp_path / "bad.md"
+    prompt_file.write_text("For list tasks call `add_items_to_list`.", encoding="utf-8")
+    preset = PromptPreset(
+        name="bad",
+        path=prompt_file,
+        summary="Bad prompt",
+        goals=("tool_first",),
+        scenarios=("list_basics",),
+    )
+
+    findings = review_prompt_preset(
+        preset,
+        available_scenarios={
+            "list_basics",
+        },
+    )
+
+    assert any(
+        finding.code == "unknown_tool_reference" and "add_items_to_list" in finding.message
+        for finding in findings
+    )
+
+
+def test_review_prompt_preset_flags_missing_review_scenario(tmp_path):
+    prompt_file = tmp_path / "sample.md"
+    prompt_file.write_text("Use tools when available.", encoding="utf-8")
+    preset = PromptPreset(
+        name="sample",
+        path=prompt_file,
+        summary="Sample prompt",
+        goals=("tool_first",),
+        scenarios=("missing_scenario",),
+    )
+
+    findings = review_prompt_preset(preset, available_scenarios={"utility_time_date"})
+
+    assert any(finding.code == "unknown_scenario" for finding in findings)
+
+
+def test_resolve_prompt_reference_from_preset():
+    text, preset_name, source = resolve_prompt_reference(prompt_preset="tool_reliability")
+
+    assert "Always call tools" in text
+    assert preset_name == "tool_reliability"
+    assert source == "preset:tool_reliability"


### PR DESCRIPTION
## Summary
- add prompt-file loading and prompt preset catalog support for CLI and GUI defaults
- add prompt review tooling and tests so prompt presets have a repeatable lint/benchmark workflow
- make prompt presets a first-class benchmark axis and add a prompt matrix example plus leaderboard prompt-impact reporting

## Testing
- uv run pytest tests/test_prompting.py tests/test_benchmark.py tests/test_cli.py -q

Closes #50