### PR TITLE
feat: add local-server direct-routing smoke coverage

### DIFF
--- a/scripts/manual_voice_smoke.py
+++ b/scripts/manual_voice_smoke.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Single-turn voice smoke test: STT -> LLM/tools -> TTS.
+
+Readable manual check for the user-facing pipeline on the current machine.
+
+Examples:
+  UV_CACHE_DIR=.uv-cache TALKBOT_LOCAL_DIRECT_TOOL_ROUTING=1 \
+    uv run python scripts/manual_voice_smoke.py
+
+  UV_CACHE_DIR=.uv-cache TALKBOT_LOCAL_DIRECT_TOOL_ROUTING=1 \
+    uv run python scripts/manual_voice_smoke.py --no-speak
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from talkbot.llm import LLMProviderError, create_llm_client, supports_tools
+from talkbot.text_utils import strip_thinking
+from talkbot.tools import register_all_tools
+from talkbot.tts import TTSManager
+from talkbot.voice import MissingVoiceDependencies, VoiceConfig, VoicePipeline
+
+
+load_dotenv()
+
+
+DEFAULT_LOCAL_SERVER_MODEL = "qwen3.5-0.8b-q8_0.gguf"
+
+
+def _default_provider() -> str:
+    return os.getenv("TALKBOT_LLM_PROVIDER", "local_server")
+
+
+def _default_model(provider: str) -> str:
+    if provider == "local_server":
+        return (os.getenv("TALKBOT_LOCAL_SERVER_MODEL") or DEFAULT_LOCAL_SERVER_MODEL).strip()
+    if provider == "openrouter":
+        return (os.getenv("TALKBOT_DEFAULT_MODEL") or "mistralai/ministral-3b-2512").strip()
+    return (os.getenv("TALKBOT_DEFAULT_MODEL") or "qwen/qwen3-1.7b").strip()
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    provider = _default_provider()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--provider", default=provider, choices=["local", "local_server", "openrouter"])
+    parser.add_argument("--model", default=_default_model(provider))
+    parser.add_argument("--local-server-url", default=os.getenv("TALKBOT_LOCAL_SERVER_URL", "http://127.0.0.1:8000/v1"))
+    parser.add_argument("--local-server-api-key", default=os.getenv("TALKBOT_LOCAL_SERVER_API_KEY", ""))
+    parser.add_argument("--api-key", default=os.getenv("OPENROUTER_API_KEY", ""))
+    parser.add_argument("--local-model-path", default=os.getenv("TALKBOT_LOCAL_MODEL_PATH", ""))
+    parser.add_argument("--llamacpp-bin", default=os.getenv("TALKBOT_LLAMACPP_BIN", "llama-cli"))
+    parser.add_argument("--backend", default=os.getenv("TALKBOT_DEFAULT_TTS_BACKEND", "kittentts"))
+    parser.add_argument("--voice", default=None)
+    parser.add_argument("--rate", type=int, default=175)
+    parser.add_argument("--volume", type=float, default=1.0)
+    parser.add_argument("--stt-model", default="small.en")
+    parser.add_argument("--language", default="en")
+    parser.add_argument("--vad-threshold", type=float, default=0.3)
+    parser.add_argument("--vad-min-silence-ms", type=int, default=1200)
+    parser.add_argument("--sample-rate", type=int, default=16000)
+    parser.add_argument("--device-in", default=None)
+    parser.add_argument("--device-out", default=None)
+    parser.add_argument("--system", default=os.getenv("TALKBOT_AGENT_PROMPT", ""))
+    parser.add_argument("--no-tools", action="store_true")
+    parser.add_argument("--no-speak", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _maybe_int(value: str | None):
+    if value is None:
+        return None
+    return int(value) if value.isdigit() else value
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+
+    config = VoiceConfig(
+        sample_rate=args.sample_rate,
+        vad_threshold=args.vad_threshold,
+        min_silence_ms=args.vad_min_silence_ms,
+        stt_model=args.stt_model,
+        stt_language=args.language,
+        device_in=_maybe_int(args.device_in),
+        device_out=_maybe_int(args.device_out),
+    )
+
+    try:
+        print("STT: speak once, then pause.", flush=True)
+        pipeline = VoicePipeline(
+            api_key=args.api_key or None,
+            provider=args.provider,
+            model=args.model,
+            local_model_path=args.local_model_path or None,
+            llamacpp_bin=args.llamacpp_bin or None,
+            local_server_url=args.local_server_url or None,
+            local_server_api_key=args.local_server_api_key or None,
+            tts_backend=args.backend or None,
+            tts_voice=args.voice,
+            tts_rate=args.rate,
+            tts_volume=args.volume,
+            speak=False,
+            system_prompt=args.system or None,
+            use_tools=not args.no_tools,
+            config=config,
+        )
+        transcript = pipeline.transcribe_once()
+        if not transcript:
+            print("STT: no transcript generated.", flush=True)
+            return 1
+        print(f"STT: {transcript}", flush=True)
+
+        print("LLM: generating response...", flush=True)
+        with create_llm_client(
+            provider=args.provider,
+            model=args.model,
+            api_key=args.api_key or None,
+            local_model_path=args.local_model_path or None,
+            llamacpp_bin=args.llamacpp_bin or None,
+            local_server_url=args.local_server_url or None,
+            local_server_api_key=args.local_server_api_key or None,
+        ) as client:
+            if not args.no_tools and supports_tools(client):
+                register_all_tools(client)
+                response = client.chat_with_system_tools(transcript, system_prompt=args.system or None)
+            else:
+                response = client.simple_chat(transcript, system_prompt=args.system or None)
+
+        visible = strip_thinking(response)
+        print(f"LLM: {visible}", flush=True)
+
+        if args.no_speak:
+            print("TTS: skipped (--no-speak).", flush=True)
+            return 0
+
+        print(f"TTS: speaking via {args.backend}...", flush=True)
+        tts = TTSManager(rate=args.rate, volume=args.volume, backend=args.backend or None)
+        if args.voice:
+            tts.set_voice(args.voice)
+        tts.speak(visible)
+        print("TTS: done.", flush=True)
+        return 0
+    except MissingVoiceDependencies as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        print("Install voice dependencies with: uv sync --extra voice", file=sys.stderr)
+        return 1
+    except (LLMProviderError, RuntimeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("\nStopped.", flush=True)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_cli_uat.py
+++ b/scripts/run_cli_uat.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""End-to-end CLI UAT runner for TalkBot.
+
+Exercises the real `talkbot` CLI entrypoints with the main user journeys:
+- ask the time
+- ask for information
+- remember and recall something
+- make and read a grocery list
+- set a timer and wait for the alert
+- hold an extended conversation
+
+By default this script isolates data in a temporary directory so it does not
+pollute the user's normal `~/.talkbot` memory/lists. Pass `--data-dir` to keep
+or inspect the persisted state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import queue
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_LOCAL_SERVER_MODEL = "qwen3.5-0.8b-q8_0.gguf"
+DEFAULT_LOCAL_SERVER_URL = "http://127.0.0.1:8000/v1"
+
+
+@dataclass
+class ScenarioResult:
+    name: str
+    passed: bool
+    details: str
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--provider", default="local_server", choices=["local", "local_server", "openrouter"])
+    parser.add_argument("--model", default=DEFAULT_LOCAL_SERVER_MODEL)
+    parser.add_argument("--local-server-url", default=DEFAULT_LOCAL_SERVER_URL)
+    parser.add_argument("--backend", default=os.getenv("TALKBOT_DEFAULT_TTS_BACKEND", "kittentts"))
+    parser.add_argument("--speak", action="store_true", help="Enable TTS so you can hear the responses.")
+    parser.add_argument("--api-key", default=os.getenv("OPENROUTER_API_KEY", ""))
+    parser.add_argument(
+        "--data-dir",
+        default=None,
+        help="Persistent tool data directory. Defaults to a temporary isolated directory.",
+    )
+    parser.add_argument(
+        "--keep-data",
+        action="store_true",
+        help="Keep the temporary data directory when the script exits.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=120,
+        help="Per-command timeout in seconds (default: 120).",
+    )
+    return parser.parse_args(argv)
+
+
+def _base_env(args: argparse.Namespace, data_dir: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["UV_CACHE_DIR"] = str(Path.cwd() / ".uv-cache")
+    env["TALKBOT_DATA_DIR"] = str(data_dir)
+    env["TALKBOT_LOCAL_DIRECT_TOOL_ROUTING"] = "1"
+    if args.api_key:
+        env["OPENROUTER_API_KEY"] = args.api_key
+    return env
+
+
+def _base_cmd(args: argparse.Namespace) -> list[str]:
+    return [
+        "uv",
+        "run",
+        "talkbot",
+        "--provider",
+        args.provider,
+        "--model",
+        args.model,
+        "--local-server-url",
+        args.local_server_url,
+    ]
+
+
+def _chat_cmd(args: argparse.Namespace, prompt: str) -> list[str]:
+    cmd = _base_cmd(args) + ["chat", prompt, "--tools"]
+    if not args.speak:
+        cmd.append("--no-speak")
+    else:
+        cmd.extend(["--backend", args.backend])
+    return cmd
+
+
+def _run_chat(args: argparse.Namespace, env: dict[str, str], prompt: str) -> tuple[bool, str]:
+    proc = subprocess.run(
+        _chat_cmd(args, prompt),
+        cwd=Path.cwd(),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=args.timeout,
+    )
+    output = (proc.stdout + proc.stderr).strip()
+    return proc.returncode == 0, output
+
+
+class InteractiveSession:
+    def __init__(self, cmd: list[str], env: dict[str, str], timeout: int) -> None:
+        self.proc = subprocess.Popen(
+            cmd,
+            cwd=Path.cwd(),
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        self.timeout = timeout
+        self._lines: list[str] = []
+        self._queue: queue.Queue[str] = queue.Queue()
+        self._reader = threading.Thread(target=self._read_stdout, daemon=True)
+        self._reader.start()
+
+    def _read_stdout(self) -> None:
+        assert self.proc.stdout is not None
+        for line in self.proc.stdout:
+            clean = line.rstrip("\n")
+            self._lines.append(clean)
+            self._queue.put(clean)
+
+    def send_line(self, text: str) -> None:
+        assert self.proc.stdin is not None
+        self.proc.stdin.write(text + "\n")
+        self.proc.stdin.flush()
+
+    def wait_for(self, pattern: str, *, timeout: int | None = None) -> bool:
+        compiled = re.compile(pattern)
+        deadline = time.time() + (timeout or self.timeout)
+        while time.time() < deadline:
+            try:
+                line = self._queue.get(timeout=0.5)
+            except queue.Empty:
+                if self.proc.poll() is not None:
+                    break
+                continue
+            if compiled.search(line):
+                return True
+        return any(compiled.search(line) for line in self._lines)
+
+    def finish(self) -> tuple[int, str]:
+        if self.proc.stdin and not self.proc.stdin.closed:
+            try:
+                self.proc.stdin.close()
+            except Exception:
+                pass
+        try:
+            code = self.proc.wait(timeout=self.timeout)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            code = self.proc.wait(timeout=5)
+        self._reader.join(timeout=1)
+        return code, "\n".join(self._lines)
+
+
+def _say_cmd(args: argparse.Namespace) -> list[str]:
+    cmd = _base_cmd(args) + ["say", "--tools"]
+    if args.speak:
+        cmd.extend(["--backend", args.backend])
+    else:
+        cmd.extend(["--backend", args.backend, "--volume", "0"])
+    return cmd
+
+
+def _scenario_time(args: argparse.Namespace, env: dict[str, str]) -> ScenarioResult:
+    ok, output = _run_chat(args, env, "What time is it?")
+    passed = ok and "AI:" in output and re.search(r"\b\d{2}:\d{2}:\d{2}\b", output) is not None
+    return ScenarioResult("Ask Time", passed, output)
+
+
+def _scenario_information(args: argparse.Namespace, env: dict[str, str]) -> ScenarioResult:
+    ok, output = _run_chat(args, env, "What is 15 percent of 47 dollars?")
+    passed = ok and "AI:" in output and "7.05" in output
+    return ScenarioResult("Ask Information", passed, output)
+
+
+def _scenario_memory(args: argparse.Namespace, env: dict[str, str]) -> ScenarioResult:
+    ok_store, store_output = _run_chat(args, env, "Remember that my project codename is Falcon.")
+    ok_recall, recall_output = _run_chat(args, env, "What did you remember about my project codename?")
+    passed = ok_store and ok_recall and "project_codename" in recall_output and "falcon" in recall_output.lower()
+    return ScenarioResult("Remember Something", passed, store_output + "\n---\n" + recall_output)
+
+
+def _scenario_list(args: argparse.Namespace, env: dict[str, str]) -> ScenarioResult:
+    ok_make, make_output = _run_chat(args, env, "Create a grocery list and add milk.")
+    ok_read, read_output = _run_chat(args, env, "What is on my grocery list?")
+    passed = ok_make and ok_read and "milk" in read_output.lower()
+    return ScenarioResult("Make And Read Grocery List", passed, make_output + "\n---\n" + read_output)
+
+
+def _scenario_timer(args: argparse.Namespace, env: dict[str, str]) -> ScenarioResult:
+    cmd = _say_cmd(args)
+    session = InteractiveSession(cmd, env, timeout=args.timeout)
+    session.wait_for(r"Interactive mode started", timeout=10)
+    session.send_line("Set a timer for 3 seconds.")
+    saw_ack = session.wait_for(r"Timer #|fire in 3 seconds|AI:", timeout=30)
+    saw_alert = session.wait_for(r"\[TIMER\].*done|is done!", timeout=15)
+    session.send_line("exit")
+    code, output = session.finish()
+    passed = saw_ack and saw_alert
+    if code != 0:
+        output = f"[exit_code={code}]\n{output}"
+    return ScenarioResult("Set Timer", passed, output)
+
+
+def _scenario_extended_conversation(args: argparse.Namespace, env: dict[str, str]) -> ScenarioResult:
+    cmd = _say_cmd(args)
+    session = InteractiveSession(cmd, env, timeout=args.timeout)
+    session.wait_for(r"Interactive mode started", timeout=10)
+    prompts = [
+        "Remember that my launch codename is Atlas.",
+        "Create a grocery list and add eggs.",
+        "What is on my grocery list?",
+        "What did you remember about my launch codename?",
+        "What time is it?",
+        "exit",
+    ]
+    for prompt in prompts:
+        session.send_line(prompt)
+        time.sleep(0.5)
+    code, output = session.finish()
+    passed = (
+        code == 0
+        and "eggs" in output.lower()
+        and "launch_codename: atlas" in output.lower()
+        and re.search(r"\b\d{2}:\d{2}:\d{2}\b", output) is not None
+    )
+    return ScenarioResult("Extended Conversation", passed, output)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    temp_dir: tempfile.TemporaryDirectory[str] | None = None
+    if args.data_dir:
+        data_dir = Path(args.data_dir).expanduser()
+        data_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        temp_dir = tempfile.TemporaryDirectory(prefix="talkbot-uat-")
+        data_dir = Path(temp_dir.name)
+
+    env = _base_env(args, data_dir)
+
+    print("CLI UAT")
+    print("=======")
+    print(f"Provider: {args.provider}")
+    print(f"Model: {args.model}")
+    print(f"Server: {args.local_server_url}")
+    print(f"Data dir: {data_dir}")
+    print(f"Speak: {'on' if args.speak else 'off'}")
+    print()
+
+    scenarios = [
+        _scenario_time,
+        _scenario_information,
+        _scenario_memory,
+        _scenario_list,
+        _scenario_timer,
+        _scenario_extended_conversation,
+    ]
+
+    results: list[ScenarioResult] = []
+    for scenario in scenarios:
+        result = scenario(args, env)
+        results.append(result)
+        status = "PASS" if result.passed else "FAIL"
+        print(f"[{status}] {result.name}")
+        print(result.details)
+        print()
+
+    failed = [r for r in results if not r.passed]
+    print("Summary")
+    print("=======")
+    print(f"Passed: {len(results) - len(failed)}/{len(results)}")
+    if failed:
+        print("Failed scenarios:")
+        for result in failed:
+            print(f"- {result.name}")
+    else:
+        print("All CLI UAT scenarios passed.")
+
+    if temp_dir is not None and not args.keep_data:
+        temp_dir.cleanup()
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_voice_uat.py
+++ b/scripts/run_voice_uat.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Guided voice UAT: user says prompted phrases, then hears the response.
+
+This is a manual acceptance script for the real user flow:
+mic -> STT -> LLM/tools -> TTS
+
+It prints the phrase to say for each step, listens once, shows the transcript,
+speaks the assistant response, and records a simple pass/fail summary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from talkbot.llm import LLMProviderError, create_llm_client, supports_tools
+from talkbot.text_utils import strip_thinking
+from talkbot.tools import register_all_tools, set_alert_callback
+from talkbot.tts import TTSManager
+from talkbot.voice import MissingVoiceDependencies, VoiceConfig, VoicePipeline
+
+
+load_dotenv()
+
+
+DEFAULT_LOCAL_SERVER_MODEL = "qwen3.5-0.8b-q8_0.gguf"
+
+
+@dataclass(frozen=True)
+class VoiceStep:
+    name: str
+    phrase: str
+    expect: str
+
+
+STEPS = [
+    VoiceStep("Ask Time", "What time is it?", "Hear the current time."),
+    VoiceStep(
+        "Ask Information",
+        "What is 15 percent of 47 dollars?",
+        "Hear a calculator answer close to 7.05.",
+    ),
+    VoiceStep(
+        "Remember Something",
+        "Remember that my project codename is Falcon.",
+        "Hear a confirmation that Falcon was remembered.",
+    ),
+    VoiceStep(
+        "Recall Something",
+        "What did you remember about my project codename?",
+        "Hear Falcon read back.",
+    ),
+    VoiceStep(
+        "Make Grocery List",
+        "Create a grocery list and add milk.",
+        "Hear confirmation that milk was added to the grocery list.",
+    ),
+    VoiceStep(
+        "Read Grocery List",
+        "What is on my grocery list?",
+        "Hear milk read back from the grocery list.",
+    ),
+    VoiceStep(
+        "Set Timer",
+        "Set a timer for 3 seconds.",
+        "Hear timer confirmation now, then a spoken timer alert a few seconds later.",
+    ),
+]
+
+
+def _default_provider() -> str:
+    return os.getenv("TALKBOT_LLM_PROVIDER", "local_server")
+
+
+def _default_model(provider: str) -> str:
+    if provider == "local_server":
+        configured = (os.getenv("TALKBOT_LOCAL_SERVER_MODEL") or "").strip()
+        return configured or DEFAULT_LOCAL_SERVER_MODEL
+    if provider == "openrouter":
+        return (os.getenv("TALKBOT_DEFAULT_MODEL") or "mistralai/ministral-3b-2512").strip()
+    return (os.getenv("TALKBOT_DEFAULT_MODEL") or "qwen/qwen3-1.7b").strip()
+
+
+def _maybe_int(value: str | None):
+    if value is None:
+        return None
+    return int(value) if value.isdigit() else value
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    provider = _default_provider()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--provider", default=provider, choices=["local", "local_server", "openrouter"])
+    parser.add_argument("--model", default=_default_model(provider))
+    parser.add_argument("--local-server-url", default=os.getenv("TALKBOT_LOCAL_SERVER_URL", "http://127.0.0.1:8000/v1"))
+    parser.add_argument("--local-server-api-key", default=os.getenv("TALKBOT_LOCAL_SERVER_API_KEY", ""))
+    parser.add_argument("--api-key", default=os.getenv("OPENROUTER_API_KEY", ""))
+    parser.add_argument("--local-model-path", default=os.getenv("TALKBOT_LOCAL_MODEL_PATH", ""))
+    parser.add_argument("--llamacpp-bin", default=os.getenv("TALKBOT_LLAMACPP_BIN", "llama-cli"))
+    parser.add_argument("--backend", default=os.getenv("TALKBOT_DEFAULT_TTS_BACKEND", "kittentts"))
+    parser.add_argument("--voice", default=None)
+    parser.add_argument("--rate", type=int, default=175)
+    parser.add_argument("--volume", type=float, default=1.0)
+    parser.add_argument("--stt-model", default="small.en")
+    parser.add_argument("--language", default="en")
+    parser.add_argument("--vad-threshold", type=float, default=0.3)
+    parser.add_argument("--vad-min-silence-ms", type=int, default=1200)
+    parser.add_argument("--sample-rate", type=int, default=16000)
+    parser.add_argument("--device-in", default=None)
+    parser.add_argument("--device-out", default=None)
+    parser.add_argument("--system", default=os.getenv("TALKBOT_AGENT_PROMPT", ""))
+    parser.add_argument("--no-tools", action="store_true")
+    parser.add_argument("--no-speak", action="store_true")
+    parser.add_argument(
+        "--data-dir",
+        default=None,
+        help="Persistent tool data directory. Defaults to a temporary isolated directory.",
+    )
+    parser.add_argument(
+        "--keep-data",
+        action="store_true",
+        help="Keep the temporary data directory when the script exits.",
+    )
+    return parser.parse_args(argv)
+
+
+def _prompt_choice(prompt: str, valid: set[str]) -> str:
+    while True:
+        value = input(prompt).strip().lower()
+        if value in valid:
+            return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+
+    temp_dir: tempfile.TemporaryDirectory[str] | None = None
+    if args.data_dir:
+        data_dir = Path(args.data_dir).expanduser()
+        data_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        temp_dir = tempfile.TemporaryDirectory(prefix="talkbot-voice-uat-")
+        data_dir = Path(temp_dir.name)
+
+    os.environ["TALKBOT_DATA_DIR"] = str(data_dir)
+    os.environ["TALKBOT_LOCAL_DIRECT_TOOL_ROUTING"] = "1"
+
+    config = VoiceConfig(
+        sample_rate=args.sample_rate,
+        vad_threshold=args.vad_threshold,
+        min_silence_ms=args.vad_min_silence_ms,
+        stt_model=args.stt_model,
+        stt_language=args.language,
+        device_in=_maybe_int(args.device_in),
+        device_out=_maybe_int(args.device_out),
+    )
+
+    pipeline = VoicePipeline(
+        api_key=args.api_key or None,
+        provider=args.provider,
+        model=args.model,
+        local_model_path=args.local_model_path or None,
+        llamacpp_bin=args.llamacpp_bin or None,
+        local_server_url=args.local_server_url or None,
+        local_server_api_key=args.local_server_api_key or None,
+        tts_backend=args.backend or None,
+        tts_voice=args.voice,
+        tts_rate=args.rate,
+        tts_volume=args.volume,
+        speak=False,
+        system_prompt=args.system or None,
+        use_tools=not args.no_tools,
+        config=config,
+    )
+
+    print("Voice UAT")
+    print("=========")
+    print(f"Provider: {args.provider}")
+    print(f"Model: {args.model}")
+    print(f"Server: {args.local_server_url}")
+    print(f"Data dir: {data_dir}")
+    print(f"TTS: {'off' if args.no_speak else args.backend}")
+    print()
+    print("For each step:")
+    print("1. press Enter")
+    print("2. say the shown phrase")
+    print("3. pause and let STT finish")
+    print("4. listen to the spoken result")
+    print()
+
+    messages: list[dict[str, str]] = []
+    if args.system:
+        messages.append({"role": "system", "content": args.system})
+
+    results: list[tuple[str, bool]] = []
+
+    try:
+        with create_llm_client(
+            provider=args.provider,
+            model=args.model,
+            api_key=args.api_key or None,
+            local_model_path=args.local_model_path or None,
+            llamacpp_bin=args.llamacpp_bin or None,
+            local_server_url=args.local_server_url or None,
+            local_server_api_key=args.local_server_api_key or None,
+        ) as client:
+            if not args.no_tools and supports_tools(client):
+                register_all_tools(client)
+
+            tts = None
+            if not args.no_speak:
+                tts = TTSManager(rate=args.rate, volume=args.volume, backend=args.backend or None)
+                if args.voice:
+                    tts.set_voice(args.voice)
+                set_alert_callback(tts.speak)
+                print("TTS: Ready to go.")
+                tts.speak("Ready to go.")
+            else:
+                print("Ready to go.")
+
+            for idx, step in enumerate(STEPS, start=1):
+                print(f"[{idx}/{len(STEPS)}] {step.name}")
+                print(f"Say: {step.phrase}")
+                print(f"Expected: {step.expect}")
+
+                while True:
+                    action = _prompt_choice(
+                        "Press Enter to listen, or type [s]kip / [q]uit: ",
+                        {"", "s", "q"},
+                    )
+                    if action == "s":
+                        results.append((step.name, False))
+                        print("Skipped.\n")
+                        break
+                    if action == "q":
+                        raise KeyboardInterrupt
+
+                    print("Listening...", flush=True)
+                    transcript = pipeline.transcribe_once()
+                    if not transcript:
+                        retry = _prompt_choice(
+                            "No transcript. Retry? [Enter=yes / s=skip / q=quit]: ",
+                            {"", "s", "q"},
+                        )
+                        if retry == "":
+                            continue
+                        if retry == "s":
+                            results.append((step.name, False))
+                            print("Skipped.\n")
+                            break
+                        raise KeyboardInterrupt
+
+                    print(f"STT: {transcript}")
+                    messages.append({"role": "user", "content": transcript})
+
+                    if not args.no_tools and supports_tools(client):
+                        response = client.chat_with_tools(messages)
+                    else:
+                        response = client.simple_chat(transcript, system_prompt=args.system or None)
+
+                    visible = strip_thinking(response)
+                    print(f"AI: {visible}")
+                    messages.append({"role": "assistant", "content": visible})
+
+                    if tts is not None:
+                        tts.speak(visible)
+
+                    verdict = _prompt_choice(
+                        "Did this step work for you? [Enter=yes / n=no / r=retry / q=quit]: ",
+                        {"", "n", "r", "q"},
+                    )
+                    if verdict == "":
+                        results.append((step.name, True))
+                        print()
+                        break
+                    if verdict == "n":
+                        results.append((step.name, False))
+                        print()
+                        break
+                    if verdict == "r":
+                        messages.pop()
+                        messages.pop()
+                        print("Retrying the same step.\n")
+                        continue
+                    raise KeyboardInterrupt
+
+            print("Summary")
+            print("=======")
+            passed = sum(1 for _name, ok in results if ok)
+            print(f"Passed: {passed}/{len(results)}")
+            for name, ok in results:
+                print(f"[{'PASS' if ok else 'FAIL'}] {name}")
+            return 0 if passed == len(STEPS) else 1
+    except MissingVoiceDependencies as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        print("Install voice dependencies with: uv sync --extra voice", file=sys.stderr)
+        return 1
+    except (LLMProviderError, RuntimeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        return 130
+    finally:
+        if temp_dir is not None and not args.keep_data:
+            temp_dir.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/talkbot/llm.py
+++ b/src/talkbot/llm.py
@@ -127,6 +127,204 @@ def _extract_remember_intent(text: str) -> tuple[str, str] | None:
     return key, value
 
 
+def _normalize_memory_key(text: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9_ ]+", " ", str(text or "").strip().lower())
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned.replace(" ", "_")
+
+
+def _normalize_list_name_hint(text: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9_ ]+", " ", str(text or "").strip().lower())
+    cleaned = re.sub(r"\b(?:my|the|a|an)\b", " ", cleaned)
+    cleaned = re.sub(r"\blist\b", " ", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned.replace(" ", "_")
+
+
+def _direct_tool_calls_from_user(messages: list[dict[str, Any]]) -> list[dict]:
+    """Deterministic tool-call extraction for common user intents."""
+    user_text = _latest_user_text(messages).lower()
+    if not user_text:
+        return []
+    assistant_text = _latest_assistant_text(messages).lower()
+
+    if "what time" in user_text or "current time" in user_text:
+        return [{"id": "direct-time-0", "function": {"name": "get_current_time", "arguments": "{}"}}]
+    if "what date" in user_text or "current date" in user_text:
+        return [{"id": "direct-date-0", "function": {"name": "get_current_date", "arguments": "{}"}}]
+    if "flip a coin" in user_text or "coin flip" in user_text:
+        return [{"id": "direct-coin-0", "function": {"name": "flip_coin", "arguments": "{}"}}]
+    if "what lists do you have" in user_text or "list all lists" in user_text:
+        return [{"id": "direct-lists-0", "function": {"name": "list_all_lists", "arguments": "{}"}}]
+    if "list timers" in user_text or "active timers" in user_text:
+        return [{"id": "direct-timers-0", "function": {"name": "list_timers", "arguments": "{}"}}]
+
+    remember = _extract_remember_intent(user_text)
+    if remember:
+        key, value = remember
+        return [
+            {
+                "id": "direct-remember-0",
+                "function": {
+                    "name": "remember",
+                    "arguments": json.dumps({"key": key, "value": value}),
+                },
+            }
+        ]
+
+    create_add_match = re.search(
+        r"\b(?:create|make|start)\s+(?:a\s+|an\s+|my\s+)?([a-z0-9_ ]+?)\s+list\s+and\s+add\s+(.+)$",
+        user_text,
+    )
+    if create_add_match:
+        list_name = _normalize_list_name_hint(create_add_match.group(1))
+        items_text = create_add_match.group(2).strip().strip(".!?")
+        if list_name and items_text:
+            return [
+                {
+                    "id": "direct-create-list-0",
+                    "function": {
+                        "name": "create_list",
+                        "arguments": json.dumps({"list_name": list_name}),
+                    },
+                },
+                {
+                    "id": "direct-add-list-0",
+                    "function": {
+                        "name": "add_to_list",
+                        "arguments": json.dumps({"list_name": list_name, "items": items_text}),
+                    },
+                },
+            ]
+
+    get_list_match = re.search(
+        r"\b(?:what(?:'s|\s+is)?\s+on|show|read)\s+(?:my\s+|the\s+)?([a-z0-9_ ]+?)\s+list\??$",
+        user_text,
+    )
+    if get_list_match:
+        list_name = _normalize_list_name_hint(get_list_match.group(1))
+        if list_name:
+            return [
+                {
+                    "id": "direct-get-list-0",
+                    "function": {
+                        "name": "get_list",
+                        "arguments": json.dumps({"list_name": list_name}),
+                    },
+                }
+            ]
+
+    percent_match = re.search(
+        r"(\d+(?:\.\d+)?)\s*percent\s+of\s+(\d+(?:\.\d+)?)",
+        user_text,
+    )
+    if percent_match:
+        pct = percent_match.group(1)
+        val = percent_match.group(2)
+        expr = f"({pct}/100)*{val}"
+        return [
+            {
+                "id": "direct-calc-percent-0",
+                "function": {
+                    "name": "calculator",
+                    "arguments": json.dumps({"formula": expr}),
+                },
+            }
+        ]
+
+    calc_match = re.search(
+        r"\b(?:what\s+is|calculate|compute)\s+([-+/*().\d\s]+)\??$",
+        user_text,
+    )
+    if calc_match and re.search(r"\d", calc_match.group(1)):
+        formula = calc_match.group(1).strip()
+        if formula:
+            return [
+                {
+                    "id": "direct-calc-0",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": json.dumps({"formula": formula}),
+                    },
+                }
+            ]
+
+    divide_match = re.search(r"\bdivide\s+that\s+by\s+(\d+(?:\.\d+)?)\b", user_text)
+    if divide_match:
+        denom = float(divide_match.group(1))
+        prior = _extract_last_number(assistant_text)
+        if prior is not None and denom != 0:
+            expr = f"({prior})/{denom}"
+            return [
+                {
+                    "id": "direct-calc-divide-0",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": json.dumps({"formula": expr}),
+                    },
+            }
+        ]
+
+    recall_match = re.search(
+        r"\b(?:what\s+did\s+you\s+remember\s+about|what\s+do\s+you\s+remember\s+about|recall|what\s+is)\s+(?:my\s+)?([a-z0-9_ ]{2,40})\??$",
+        user_text,
+    )
+    if recall_match:
+        key = _normalize_memory_key(recall_match.group(1))
+        if key:
+            return [
+                {
+                    "id": "direct-recall-0",
+                    "function": {
+                        "name": "recall",
+                        "arguments": json.dumps({"key": key}),
+                    },
+                }
+            ]
+
+    cancel_match = re.search(r"cancel\s+timer\s+#?(\d+)", user_text)
+    if cancel_match:
+        return [
+            {
+                "id": "direct-cancel-timer-0",
+                "function": {
+                    "name": "cancel_timer",
+                    "arguments": json.dumps({"timer_id": cancel_match.group(1)}),
+                },
+            }
+        ]
+
+    timer_match = re.search(
+        r"(?:set\s+)?(?:a\s+)?timer(?:\s+for)?\s+(\d+)\s*(?:s|sec|secs|second|seconds)\b",
+        user_text,
+    )
+    if timer_match:
+        return [
+            {
+                "id": "direct-set-timer-0",
+                "function": {
+                    "name": "set_timer",
+                    "arguments": json.dumps({"seconds": int(timer_match.group(1))}),
+                },
+            }
+        ]
+
+    dm = re.search(r"\b(\d+)\s*d\s*(\d+)(?:s)?\b", user_text)
+    if dm:
+        count = int(dm.group(1))
+        sides = int(dm.group(2))
+        return [
+            {
+                "id": "direct-dice-0",
+                "function": {
+                    "name": "roll_dice",
+                    "arguments": json.dumps({"sides": sides, "count": count}),
+                },
+            }
+        ]
+    return []
+
+
 def _rewrite_tool_call_for_user_intent(
     function_name: str,
     function_args: dict[str, Any],
@@ -536,7 +734,7 @@ class LocalLlamaCppClient:
         executed_call_results: dict[str, str] = {}
 
         # Fast-path common spoken intents before asking model to format a tool call.
-        direct_calls = self._direct_tool_calls_from_user(messages) if self.direct_tool_routing else []
+        direct_calls = _direct_tool_calls_from_user(messages) if self.direct_tool_routing else []
         if direct_calls:
             for tool_call in direct_calls:
                 function_name = tool_call["function"]["name"]
@@ -836,135 +1034,6 @@ class LocalLlamaCppClient:
                 ]
         return []
 
-    def _direct_tool_calls_from_user(self, messages: list[dict]) -> list[dict]:
-        """Deterministic intent routing for common voice utterances."""
-        if not messages:
-            return []
-        user_text = ""
-        for m in reversed(messages):
-            if str(m.get("role", "")).strip().lower() == "user":
-                user_text = str(m.get("content", "")).strip().lower()
-                break
-        if not user_text:
-            return []
-        assistant_text = _latest_assistant_text(messages)
-
-        if "what time" in user_text or "current time" in user_text:
-            return [{"id": "direct-time-0", "function": {"name": "get_current_time", "arguments": "{}"}}]
-        if "what date" in user_text or "current date" in user_text:
-            return [{"id": "direct-date-0", "function": {"name": "get_current_date", "arguments": "{}"}}]
-        if "flip a coin" in user_text or "coin flip" in user_text:
-            return [{"id": "direct-coin-0", "function": {"name": "flip_coin", "arguments": "{}"}}]
-        if "what lists do you have" in user_text or "list all lists" in user_text:
-            return [{"id": "direct-lists-0", "function": {"name": "list_all_lists", "arguments": "{}"}}]
-        if "list timers" in user_text or "active timers" in user_text:
-            return [{"id": "direct-timers-0", "function": {"name": "list_timers", "arguments": "{}"}}]
-        remember_match = re.search(
-            r"\bremember(?:\s+that)?\s+(?:my\s+)?([a-z0-9_ ]{2,40}?)\s+is\s+(.+)$",
-            user_text,
-        )
-        if remember_match:
-            key = remember_match.group(1).strip().replace(" ", "_")
-            value = remember_match.group(2).strip().strip(".!?")
-            if key and value:
-                return [
-                    {
-                        "id": "direct-remember-0",
-                        "function": {
-                            "name": "remember",
-                            "arguments": json.dumps({"key": key, "value": value}),
-                        },
-                    }
-                ]
-        recall_match = re.search(
-            r"\b(?:what\s+is|recall)\s+(?:my\s+)?([a-z_ ]{2,40})\??$",
-            user_text,
-        )
-        if recall_match:
-            key = recall_match.group(1).strip().replace(" ", "_")
-            if key:
-                return [
-                    {
-                        "id": "direct-recall-0",
-                        "function": {
-                            "name": "recall",
-                            "arguments": json.dumps({"key": key}),
-                        },
-                    }
-                ]
-        cancel_match = re.search(r"cancel\s+timer\s+#?(\d+)", user_text)
-        if cancel_match:
-            return [
-                {
-                    "id": "direct-cancel-timer-0",
-                    "function": {
-                        "name": "cancel_timer",
-                        "arguments": json.dumps({"timer_id": cancel_match.group(1)}),
-                    },
-                }
-            ]
-        timer_match = re.search(
-            r"(?:set\s+)?(?:a\s+)?timer(?:\s+for)?\s+(\d+)\s*(?:s|sec|secs|second|seconds)\b",
-            user_text,
-        )
-        if timer_match:
-            return [
-                {
-                    "id": "direct-set-timer-0",
-                    "function": {
-                        "name": "set_timer",
-                        "arguments": json.dumps({"seconds": int(timer_match.group(1))}),
-                    },
-                }
-            ]
-        percent_match = re.search(
-            r"(\d+(?:\.\d+)?)\s*percent\s+of\s+(\d+(?:\.\d+)?)",
-            user_text,
-        )
-        if percent_match:
-            pct = percent_match.group(1)
-            val = percent_match.group(2)
-            expr = f"({pct}/100)*{val}"
-            return [
-                {
-                    "id": "direct-calc-percent-0",
-                    "function": {
-                        "name": "calculator",
-                        "arguments": json.dumps({"formula": expr}),
-                    },
-                }
-            ]
-        divide_match = re.search(r"\bdivide\s+that\s+by\s+(\d+(?:\.\d+)?)\b", user_text)
-        if divide_match:
-            denom = float(divide_match.group(1))
-            prior = _extract_last_number(assistant_text)
-            if prior is not None and denom != 0:
-                expr = f"({prior})/{denom}"
-                return [
-                    {
-                        "id": "direct-calc-divide-0",
-                        "function": {
-                            "name": "calculator",
-                            "arguments": json.dumps({"formula": expr}),
-                        },
-                    }
-                ]
-
-        dm = re.search(r"\b(\d+)\s*d\s*(\d+)(?:s)?\b", user_text)
-        if dm:
-            count = int(dm.group(1))
-            sides = int(dm.group(2))
-            return [
-                {
-                    "id": "direct-dice-0",
-                    "function": {
-                        "name": "roll_dice",
-                        "arguments": json.dumps({"sides": sides, "count": count}),
-                    },
-                }
-            ]
-        return []
-
     def close(self) -> None:
         return None
 
@@ -1126,6 +1195,34 @@ class LocalServerClient:
         if not self.tools:
             response = self.chat_completion(messages, temperature, max_tokens)
             return _response_content(response)
+
+        latest_user_text = _latest_user_text(messages)
+        direct_calls = _direct_tool_calls_from_user(messages) if self.direct_tool_routing else []
+        if direct_calls:
+            executed_tool_summaries: list[str] = []
+            for tool_call in direct_calls:
+                function_name = tool_call["function"]["name"]
+                try:
+                    function_args = json.loads(tool_call["function"]["arguments"])
+                except Exception:
+                    function_args = {}
+                function_name, function_args = _rewrite_tool_call_for_user_intent(
+                    function_name,
+                    function_args,
+                    latest_user_text,
+                )
+                function_args = _normalize_tool_args_for_call(function_name, function_args)
+                if function_name in self.tools:
+                    tool_func = self.tools[function_name]
+                    function_args = _filter_tool_args_for_callable(tool_func, function_args)
+                    try:
+                        result = tool_func(**function_args)
+                    except Exception as e:
+                        result = f"Error executing {function_name}: {e}"
+                else:
+                    result = f"Error: Tool {function_name} not found"
+                executed_tool_summaries.append(f"{function_name}({function_args}) -> {result}")
+            return "\n".join(s.split(" -> ", 1)[-1] for s in executed_tool_summaries)
 
         # Intent routing: detect which single tool the user most likely wants.
         # When found, send only that tool's schema + tool_choice='required' so the

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from talkbot import llm as llm_module
+from talkbot.tools import register_all_tools, reset_runtime_state
 
 
 def test_local_provider_uses_repo_default_model_path(monkeypatch, tmp_path):
@@ -91,3 +92,134 @@ def test_normalize_add_to_list_item_alias():
         "add_to_list", {"item": "eggs", "list_name": "grocery"}
     )
     assert result == {"items": "eggs", "list_name": "grocery"}
+
+
+def test_direct_tool_calls_parse_memory_phrasing():
+    remember_calls = llm_module._direct_tool_calls_from_user(
+        [{"role": "user", "content": "Remember that my project codename is Falcon."}]
+    )
+    recall_calls = llm_module._direct_tool_calls_from_user(
+        [{"role": "user", "content": "What did you remember about my project codename?"}]
+    )
+
+    assert remember_calls == [
+        {
+            "id": "direct-remember-0",
+            "function": {
+                "name": "remember",
+                "arguments": '{"key": "project_codename", "value": "falcon"}',
+            },
+        }
+    ]
+    assert recall_calls == [
+        {
+            "id": "direct-recall-0",
+            "function": {
+                "name": "recall",
+                "arguments": '{"key": "project_codename"}',
+            },
+        }
+    ]
+
+
+def test_direct_tool_calls_do_not_misroute_math_question_to_recall():
+    calc_calls = llm_module._direct_tool_calls_from_user(
+        [{"role": "user", "content": "What is 15 percent of 47 dollars?"}]
+    )
+
+    assert calc_calls == [
+        {
+            "id": "direct-calc-percent-0",
+            "function": {
+                "name": "calculator",
+                "arguments": '{"formula": "(15/100)*47"}',
+            },
+        }
+    ]
+
+
+def test_direct_tool_calls_parse_list_create_add_and_read():
+    create_calls = llm_module._direct_tool_calls_from_user(
+        [{"role": "user", "content": "Create a grocery list and add milk."}]
+    )
+    read_calls = llm_module._direct_tool_calls_from_user(
+        [{"role": "user", "content": "What is on my grocery list?"}]
+    )
+
+    assert create_calls == [
+        {
+            "id": "direct-create-list-0",
+            "function": {
+                "name": "create_list",
+                "arguments": '{"list_name": "grocery"}',
+            },
+        },
+        {
+            "id": "direct-add-list-0",
+            "function": {
+                "name": "add_to_list",
+                "arguments": '{"list_name": "grocery", "items": "milk"}',
+            },
+        },
+    ]
+    assert read_calls == [
+        {
+            "id": "direct-get-list-0",
+            "function": {
+                "name": "get_list",
+                "arguments": '{"list_name": "grocery"}',
+            },
+        }
+    ]
+
+
+def test_local_server_direct_routing_persists_memory_without_model(monkeypatch, tmp_path):
+    monkeypatch.setenv("TALKBOT_DATA_DIR", str(tmp_path / "talkbot-data"))
+    reset_runtime_state(clear_persistent=True)
+    client = llm_module.LocalServerClient(
+        model="qwen3.5-0.8b-q8_0.gguf",
+        base_url="http://127.0.0.1:8000/v1",
+        direct_tool_routing=True,
+    )
+    register_all_tools(client)
+    monkeypatch.setattr(
+        client,
+        "chat_completion",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("model should not be called")),
+    )
+
+    stored = client.chat_with_tools(
+        [{"role": "user", "content": "Remember that my project codename is Falcon."}]
+    )
+    recalled = client.chat_with_tools(
+        [{"role": "user", "content": "What did you remember about my project codename?"}]
+    )
+
+    assert "Remembered: project_codename = falcon" == stored
+    assert "project_codename: falcon" == recalled
+
+
+def test_local_server_direct_routing_persists_list_without_model(monkeypatch, tmp_path):
+    monkeypatch.setenv("TALKBOT_DATA_DIR", str(tmp_path / "talkbot-data"))
+    reset_runtime_state(clear_persistent=True)
+    client = llm_module.LocalServerClient(
+        model="qwen3.5-0.8b-q8_0.gguf",
+        base_url="http://127.0.0.1:8000/v1",
+        direct_tool_routing=True,
+    )
+    register_all_tools(client)
+    monkeypatch.setattr(
+        client,
+        "chat_completion",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("model should not be called")),
+    )
+
+    created = client.chat_with_tools(
+        [{"role": "user", "content": "Create a grocery list and add milk."}]
+    )
+    listed = client.chat_with_tools(
+        [{"role": "user", "content": "What is on my grocery list?"}]
+    )
+
+    assert created == "Created 'grocery' list.\nAdded 'milk' to the grocery list."
+    assert listed == "Grocery list:\n- milk"


### PR DESCRIPTION
## Summary
- add deterministic local-server direct routing for common memory and list phrasing so those flows can complete without a model round-trip
- add regression coverage for natural memory/list phrases and direct-routing persistence
- add manual CLI and voice UAT helpers for end-to-end smoke testing

## Testing
- uv run pytest tests/test_llm.py -q

Closes #48