### PR TITLE
gitignore: exclude bin/ (llama.cpp built binaries)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@ models/*.gguf
 models/*.GGUF
 models/*.part
 
-# System/installation-specific tools (e.g. llama.cpp binaries)
+# System/installation-specific tools and built binaries (e.g. llama.cpp)
 tools/
+bin/
 
 # IDE
 .vscode/


### PR DESCRIPTION
Binaries built from source land in `bin/` on the control node (and potentially other machines where llama.cpp is compiled locally). These are platform-specific and shouldn't be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)