### PR TITLE
Add gemma-4-26b to benchmark matrix

### DIFF
--- a/benchmarks/model_matrix.full_remote.json
+++ b/benchmarks/model_matrix.full_remote.json
@@ -97,6 +97,14 @@
             "use_tools": true,
             "max_tokens": 512,
             "temperature": 0.0
+        },
+        {
+            "name": "openrouter-gemma-4-26b",
+            "provider": "openrouter",
+            "model": "google/gemma-4-26b-a4b-it",
+            "use_tools": true,
+            "max_tokens": 512,
+            "temperature": 0.0
         }
     ]
 }

--- a/benchmarks/model_matrix.jetson.json
+++ b/benchmarks/model_matrix.jetson.json
@@ -1,0 +1,39 @@
+{
+    "benchmark": {
+        "schema_version": "2026.1",
+        "values_file": "benchmarks/evaluation_values.json",
+        "rubric": {
+            "version": "2026.full-suite.v1",
+            "weights": {
+                "task_success_rate": 0.35,
+                "tool_selection_accuracy": 0.2,
+                "argument_accuracy": 0.15,
+                "recovery_success_rate": 0.1,
+                "multistep_success_rate": 0.1,
+                "robustness_success_rate": 0.05,
+                "context_success_rate": 0.05
+            },
+            "penalties": {
+                "latency_ms_multiplier": 0.002,
+                "memory_mb_multiplier": 0.002,
+                "tool_error_rate_multiplier": 20.0,
+                "model_error_rate_multiplier": 30.0
+            }
+        },
+        "context_analysis": {
+            "near_peak_ratio": 0.95,
+            "dropoff_ratio": 0.9
+        }
+    },
+    "profiles": [
+        {
+            "name": "jetson-gemma-4-26b-local",
+            "provider": "local_server",
+            "model": "google/gemma-4-26b-a4b-it",
+            "use_tools": true,
+            "max_tokens": 512,
+            "temperature": 0.0,
+            "_note": "gemma-4-26B-A4B via llama-server on Jetson Orin 64GB — CUDA GPU offload, ~17GB Q4_K_M"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

- Add `google/gemma-4-26b-a4b-it` (via OpenRouter) to `model_matrix.full_remote.json`
- Add `model_matrix.jetson.json` for local Jetson inference benchmark profile
- These support evaluation of the gemma-4-26b MoE model (26B params, 4B active, ~17GB at Q4_K_M)

## Test plan
- [ ] Full `model_matrix.full_remote.json` benchmark run in progress on control node
- [ ] Results will be committed as a follow-up once the benchmark completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)